### PR TITLE
Made MEL Catalog configuration global

### DIFF
--- a/config/initializers/melcatalog.rb
+++ b/config/initializers/melcatalog.rb
@@ -1,9 +1,3 @@
-if ActiveRecord::Base.connection.table_exists? 'tenants'
-  tenant = Tenant.current_tenant
-
-  if tenant && tenant.mel_catalog_enabled 
-    Melcatalog.configure do |config|
-      config.service_endpoint = tenant.mel_catalog_url
-    end
-  end
+Melcatalog.configure do |config|
+  config.service_endpoint = ENV['MEL_CATALOG_API']
 end


### PR DESCRIPTION
Per-tenant configuration was not working. At initialization time, `Tenant.current_tenant` returns nil, or public, since the current tenant is set by subdomain. That issue is to be fixed at a later date. 