### PR TITLE
Added HTML export function

### DIFF
--- a/app.json
+++ b/app.json
@@ -117,9 +117,6 @@
     "EXCEPTION_SENDER": {
       "required": true
     },
-    "GLOBAL_ALERT": {
-      "required": true
-    },
     "GOOGLE_ANALYTICS_CODE": {
       "required": false
     },

--- a/app/assets/stylesheets/documents.css.scss
+++ b/app/assets/stylesheets/documents.css.scss
@@ -41,3 +41,10 @@ body {
   }  
   
 }
+
+#tool-sidebar {
+  padding-top: 30px;
+  a {
+    margin-bottom: 10px;
+  }
+}

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -2,7 +2,7 @@
 require 'melcatalog'
 
 class DocumentsController < ApplicationController
-  before_filter :find_document, :only => [:show, :set_default_state, :preview, :publish, :archive, :snapshot, :destroy, :edit, :update]
+  before_filter :find_document, :only => [:show, :set_default_state, :preview, :publish, :export, :archive, :snapshot, :destroy, :edit, :update]
   before_filter :authenticate_user!
 
   load_and_authorize_resource :except => :create

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -21,7 +21,7 @@ class Ability
         end
       end
       can :create, Document
-      can [:read, :update, :publish, :archive, :preview, :set_default_state, :snapshot], Document, { :user_id => user.id }
+      can [:read, :update, :publish, :archive, :preview, :export, :set_default_state, :snapshot], Document, { :user_id => user.id }
       can :destroy, Document, { :user_id => user.id, :published? => false }
 
     elsif user.has_role? :student

--- a/app/views/documents/preview.html.erb
+++ b/app/views/documents/preview.html.erb
@@ -16,6 +16,9 @@
     </div>
   </div><!--/col-md-8 -->
   <div class="col-md-2" id="tool-sidebar">
+    <%= link_to("Download", document_export_path(@document), class: "btn btn-default btn-sm", role: "button") %>
+    <%= link_to("Post to COVE", "#", class: "btn btn-default btn-sm", disabled: "disabled", role: "button") %>
+    <%= link_to("Post to Github", "#", class: "btn btn-default btn-sm", disabled: "disabled", role: "button") %>
   </div><!--/col-md-2 -->
 </div><!--/row -->
 <%= render "documents/help" %>

--- a/app/views/public_documents/show.html.erb
+++ b/app/views/public_documents/show.html.erb
@@ -5,7 +5,7 @@
 <div class="row">
   <div class="col-md-8">
     <div id="textcontent">
-      <div><!-- Required for cases in which there's no HTML in the text -->
+      <div id="snapshot">
         <%= @document.text.html_safe %>
       </div>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,7 @@ AnnotationStudio::Application.routes.draw do
     post :publish
     post :archive
     post :snapshot
+    get :export
     get :preview, to: 'documents#preview'
   end
 


### PR DESCRIPTION
#### What's this PR do?
Makes it easy to export HTML documents from AS, for import to COVE editions, or elsewhere.
Closes #3 

#### How to test
- Visit a document
- Annotate
- Click Snapshot at bottom of the the filter sidebar
- Click Preview at bottom of the the filter sidebar
- Click Download from the preview page sidebar
- Double click the downloaded file -- should open either in a browser as a web page or in an editor as an HTML file, depending on your OS settings.
