### PR TITLE
added NAVSA SSO through omniauth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ patch.diff
 .idea
 /deploy.sh
 devnotes.md
+
+# Ignore application configuration
+/config/application.yml

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'puma'
 gem 'pg'
 gem "newrelic_rpm"#, "~> 3.5.7.59"
 
-gem 'devise'#, '>= 2.2.2'
+gem 'devise', '~> 3.2'
 gem 'cancancan', '~> 1.10'
 gem 'repertoire-groups', '0.0.1', :path => 'vendor/repertoire-groups-0.0.1' #, :require => 'repertoire-groups'
 gem 'acts-as-taggable-on'
@@ -24,11 +24,14 @@ gem 'apartment'
 gem 'yomu'
 gem 'net-ssh'
 gem 'select2-rails', '< 4.0'
+gem 'omniauth-oauth2', '1.3.1'
+gem 'omniauth-wordpress_hosted', github: 'jwickard/omniauth-wordpress-oauth2-plugin'
 
 group :development do
   gem 'sextant'
   gem 'meta_request'#, '0.2.1'
   gem 'highline'
+  gem 'figaro'
 end
 
 group :assets do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: git://github.com/jwickard/omniauth-wordpress-oauth2-plugin.git
+  revision: fa3915665106855738ac055b22be6b96ca37fb79
+  specs:
+    omniauth-wordpress_hosted (0.0.5)
+      omniauth-oauth2
+
 PATH
   remote: vendor/repertoire-groups-0.0.1
   specs:
@@ -146,6 +153,8 @@ GEM
       railties (>= 3.0.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
+    figaro (1.1.1)
+      thor (~> 0.14)
     fission (0.5.0)
       CFPropertyList (~> 2.2)
     fog (1.29.0)
@@ -251,6 +260,7 @@ GEM
     has_scope (0.6.0)
       actionpack (>= 3.2, < 5)
       activesupport (>= 3.2, < 5)
+    hashie (3.4.4)
     high_voltage (2.1.0)
     highline (1.7.2)
     html_writer (0.2.0)
@@ -298,6 +308,7 @@ GEM
     mini_portile (0.6.2)
     minitest (5.6.1)
     multi_json (1.11.2)
+    multi_xml (0.5.5)
     multipart-post (2.0.0)
     mustache (1.0.1)
     net-ssh (3.0.2)
@@ -305,8 +316,20 @@ GEM
     newrelic_rpm (3.14.0.305)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
+    oauth2 (1.2.0)
+      faraday (>= 0.8, < 0.10)
+      jwt (~> 1.0)
+      multi_json (~> 1.3)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 3)
     octokit (4.3.0)
       sawyer (~> 0.7.0, >= 0.5.3)
+    omniauth (1.3.1)
+      hashie (>= 1.2, < 4)
+      rack (>= 1.0, < 3)
+    omniauth-oauth2 (1.3.1)
+      oauth2 (~> 1.0)
+      omniauth (~> 1.2)
     orm_adapter (0.5.0)
     paperclip (4.3.2)
       activemodel (>= 3.2.0)
@@ -486,10 +509,11 @@ DEPENDENCIES
   coffee-rails
   database_cleaner
   delayed_job_active_record
-  devise
+  devise (~> 3.2)
   doorkeeper
   exception_notification
   factory_girl_rails
+  figaro
   fog
   friendly_id
   gon
@@ -509,6 +533,8 @@ DEPENDENCIES
   newrelic_rpm
   nokogiri
   octokit (~> 4.0)
+  omniauth-oauth2 (= 1.3.1)
+  omniauth-wordpress_hosted!
   paperclip
   pdf-reader
   pdf-reader-html

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -51,3 +51,4 @@
 //= require format_date
 //= require dont_overflow_dropdown
 //= require unload_confirmation
+//= require sign-in

--- a/app/assets/javascripts/sign-in.js
+++ b/app/assets/javascripts/sign-in.js
@@ -1,0 +1,7 @@
+$(function() {
+  $("#manual-login-toggle").click(function(event) {
+    event.preventDefault();
+    $("#manual-login").slideToggle();
+    return false;
+  });
+});

--- a/app/assets/stylesheets/offcanvas.css
+++ b/app/assets/stylesheets/offcanvas.css
@@ -131,7 +131,7 @@ body#documents.show .navbar button#leftburger,body#documents.show .navbar button
 	width: 100%;
 }
 
-.well.devise {
+.well.devise, #omniauth-links {
 	width: 360px;
 	padding-top: 0;
 }
@@ -143,6 +143,10 @@ body#documents.show .navbar button#leftburger,body#documents.show .navbar button
 	font-weight: bold;
 	font-size: 24px;
 	margin-top: 0;
+}
+
+#manual-login {
+  display: none;
 }
 
 .dropdown-menu-right {

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -1,0 +1,13 @@
+class OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  def wordpress_hosted
+    @user = User.find_for_wordpress_oauth2(request.env["omniauth.auth"], current_user)
+
+    if @user.persisted?
+      flash[:notice] = I18n.t "devise.omniauth_callbacks.success", :kind => "NAVSA"
+      sign_in_and_redirect @user, :event => :authentication #this will throw if @user is not activated
+    else
+      session["devise.wordpress_oauth2_data"] = request.env["omniauth.auth"]
+      redirect_to new_user_registration_url
+    end
+  end
+end

--- a/app/views/devise/_links.erb
+++ b/app/views/devise/_links.erb
@@ -1,10 +1,11 @@
 <ul class="list-group" id="account-management-links">
+
 <%- if controller_name != 'sessions' %>
 <li class="list-group-item"><%= link_to "Sign in", new_session_path(resource_name), :class => "" %></li>
 <% end -%>
 
-<%- if false && devise_mapping.registerable? && controller_name != 'registrations' %>
-<li class="list-group-item"><%= link_to "Register", new_registration_path(resource_name), :class => "" %></li>
+<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
+<li class="list-group-item"><%= link_to "Sign up", new_registration_path(resource_name), :class => "" %></li>
 <% end -%>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' %>
@@ -19,9 +20,4 @@
 <li class="list-group-item"><%= link_to "Resend unlock instructions?", new_unlock_path(resource_name), :class => "" %></li>
 <% end -%>
 
-<%- if devise_mapping.omniauthable? %>
-  <%- resource_class.omniauth_providers.each do |provider| %>
-    <li class="list-group-item"><%= link_to "Sign in with #{provider.to_s.titleize}", omniauth_authorize_path(resource_name, provider), :class => "btn btn-default" %></li>
-  <% end -%>
-<% end -%>
 </ul>

--- a/app/views/devise/sessions/_sign_in.html.erb
+++ b/app/views/devise/sessions/_sign_in.html.erb
@@ -1,4 +1,16 @@
+<%- if devise_mapping.omniauthable? %>
+	<ul class="list-group" id="omniauth-links">
+	  <%- resource_class.omniauth_providers.each do |provider| %>
+	  <li class="list-group-item"><%= link_to "Log in through #{I18n.t provider.to_sym, scope: [:devise, :omniauth]}", omniauth_authorize_path(resource_name, provider), :class => "btn btn-default" %></li>
+	  <% end -%>
+
+	  <li class="list-group-item"><a id="manual-login-toggle" href="#manual-login">Not a NAVSA member?</a></li>
+	</ul>
+	<div id="manual-login">
+<% end -%>
+
 <div class="well devise">
+
 	<h4>Log in</h4>
 	<%= form_for(resource, :as => resource_name, :url => session_path(resource_name), :html => { :role => "form"}) do |f| %>
 		<%= devise_error_messages! %>
@@ -18,3 +30,7 @@
 	<% end %>
 </div><!--/well -->
 <%= render "/devise/links" %>
+
+<%- if devise_mapping.omniauthable? %>
+	</div>
+<% end -%>

--- a/app/views/shared/_cove_brand.html.erb
+++ b/app/views/shared/_cove_brand.html.erb
@@ -20,17 +20,7 @@
           <li><%= render "/devise/sessions/sign_in" %></li>
       </ul>
   </div></li>
-  <li><div class="dropdown dont-overflow">
-      <button class="dropdown-toggle menu-button" type="button" id="login-form" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-          Register
-          <span class="caret"></span>
-      </button>
-      <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="login-form">
-          <li><%= render "/devise/sessions/sign_up" %></li>
-      </ul>
-  </div></li>
   <% end %>
 <% end %>
 <%= link_to(image_tag("NAVSAlogo.png"), "http://navsa.org") %>
 </ul>
-

--- a/app/views/shared/_user_menu.html.erb
+++ b/app/views/shared/_user_menu.html.erb
@@ -29,4 +29,3 @@
     <% end %>
     <%= link_to(image_tag("NAVSAlogo.png"), "http://navsa.org") %>
   </ul>
-

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -217,6 +217,11 @@ Devise.setup do |config|
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
   # config.omniauth :github, 'APP_ID', 'APP_SECRET', :scope => 'user,public_repo'
+  config.omniauth :wordpress_hosted, ENV['WP_AUTH_KEY'], ENV['WP_AUTH_SECRET'],
+                  strategy_class: OmniAuth::Strategies::WordpressHosted,
+                  client_options: {
+                    site: ENV['WP_URL']
+                  }
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -47,6 +47,8 @@ en:
       send_instructions: "You will receive an email with instructions about how to unlock your account in a few minutes."
       send_paranoid_instructions: "If your account exists, you will receive an email with instructions about how to unlock it in a few minutes."
       unlocked: "Your account has been unlocked successfully. Please sign in to continue."
+    omniauth:
+      wordpress_hosted: "NAVSA"
   errors:
     messages:
       already_confirmed: "was already confirmed, please try signing in"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ AnnotationStudio::Application.routes.draw do
   get 'public/:id' => 'public_documents#show'
   get 'review/:id' => 'public_documents#show'
 
-  devise_for :users, controllers: {registrations: 'registrations'}
+  devise_for :users, controllers: {registrations: 'registrations', omniauth_callbacks: 'omniauth_callbacks'}
 
   devise_for :admin_users, ActiveAdmin::Devise.config
   ActiveAdmin.routes(self)

--- a/db/migrate/20160912201159_add_auth_to_users.rb
+++ b/db/migrate/20160912201159_add_auth_to_users.rb
@@ -1,0 +1,6 @@
+class AddAuthToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :provider, :string
+    add_column :users, :uid, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160808210812) do
+ActiveRecord::Schema.define(version: 20160912201159) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -237,6 +237,8 @@ ActiveRecord::Schema.define(version: 20160808210812) do
     t.string   "affiliation",            limit: 255
     t.string   "slug",                   limit: 255
     t.boolean  "agreement"
+    t.string   "provider"
+    t.string   "uid"
   end
 
   add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree


### PR DESCRIPTION
#### What are the relevant tickets?
closes #15

#### What's this PR do?
Integrates a single-sign-on tool into Cove Studio, allowing users to log in through the NAVSA Wordpress site. Logging in through NAVSA is prioritized in the UI to indicate that it's the default way to access Cove Studio. If a user has an existing Cove Studio account with the same email address as their NAVSA account, that account will be automatically linked when they click 'Log in through NAVSA'.

#### How should this be manually tested?
Create an account at http://navsa.org, then visit the [PR review app](https://cove-staging-pr-74.herokuapp.com/), click "Log in", then click "Log in through NAVSA"

#### Notes
- In this first pass, email is treated as a reliable unique identifier - i.e., when you click "Log in through NAVSA", the app will link your NAVSA account to an existing account with the same email. Is that a good approach? We could require that you first be signed in to both accounts (rather than just  in order for the link to be made, if that would give additional security.
- When linking a NAVSA account to an existing account, what information should be overwritten? (e.g. first and last name).
- When a user with no pre-existing account first logs in through NAVSA, an account will be created for them. Currently, this bypasses the email confirmation (seems unnecessary if they're already logged in to NAVSA) but also the user agreement. Should there be an intermediary step where new users must accept the user agreement before a first-time authentication completes?