### PR TITLE
Made it possible to push document snapshots to COVE Editions

### DIFF
--- a/app.json
+++ b/app.json
@@ -15,6 +15,15 @@
     "HEROKU_PARENT_APP_NAME": {
       "required": true
     },
+    "COVE_URL": {
+      "required": true
+    },
+    "COVE_PASSWORD": {
+      "required": true
+    },
+    "COVE_USERNAME": {
+      "required": true
+    },
     "USE_TYPEKIT": {
       "required": true
     },
@@ -37,6 +46,9 @@
       "required": true
     },
     "GROUP_TERM": {
+      "required": true
+    },
+    "GLOBAL_ALERT": {
       "required": true
     },
     "GROUP_TERM_PLURAL": {

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -21,7 +21,7 @@ class Ability
         end
       end
       can :create, Document
-      can [:read, :update, :annotatable, :review, :publish, :archive, :preview, :export, :set_default_state, :snapshot], Document, { :user_id => user.id }
+      can [:read, :update, :annotatable, :review, :publish, :archive, :preview, :post_to_cove, :export, :set_default_state, :snapshot], Document, { :user_id => user.id }
       can :destroy, Document, { :user_id => user.id, :published? => false }
 
     elsif user.has_role? :student

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -1,25 +1,27 @@
-# t.string   "title",               limit: 255
-# t.text     "text"
-# t.datetime "created_at",                      null: false
-# t.datetime "updated_at",                      null: false
-# t.string   "author",              limit: 255
-# t.datetime "year_published"
-# t.string   "edition",             limit: 255
-# t.string   "publisher",           limit: 255
-# t.string   "source",              limit: 255
-# t.string   "rights_status",       limit: 255
-# t.string   "slug",                limit: 255
-# t.integer  "user_id"
-# t.date     "publication_date"
-# t.text     "chapters"
-# t.string   "state",               limit: 255
-# t.string   "upload_file_name",    limit: 255
-# t.string   "upload_content_type", limit: 255
-# t.integer  "upload_file_size"
-# t.datetime "upload_updated_at"
-# t.datetime "processed_at"
-# t.string   "survey_link",         limit: 255
-# t.text     "default_state"
+    # t.string   "title",               limit: 255
+    # t.text     "text"
+    # t.datetime "created_at",                      null: false
+    # t.datetime "updated_at",                      null: false
+    # t.string   "author",              limit: 255
+    # t.datetime "year_published"
+    # t.string   "edition",             limit: 255
+    # t.string   "publisher",           limit: 255
+    # t.string   "source",              limit: 255
+    # t.string   "rights_status",       limit: 255
+    # t.string   "slug",                limit: 255
+    # t.integer  "user_id"
+    # t.date     "publication_date"
+    # t.text     "chapters"
+    # t.string   "state",               limit: 255
+    # t.string   "upload_file_name",    limit: 255
+    # t.string   "upload_content_type", limit: 255
+    # t.integer  "upload_file_size"
+    # t.datetime "upload_updated_at"
+    # t.datetime "processed_at"
+    # t.string   "survey_link",         limit: 255
+    # t.text     "default_state"
+    # t.text     "snapshot"
+    # t.string   "cove_uri"
 
 require "babosa" # allows cyrillic, other characters in titles (transliterates titles for URL use)
 

--- a/app/views/documents/preview.html.erb
+++ b/app/views/documents/preview.html.erb
@@ -17,8 +17,10 @@
   </div><!--/col-md-8 -->
   <div class="col-md-2" id="tool-sidebar">
     <%= link_to("Download", document_export_path(@document), class: "btn btn-default btn-sm", role: "button") %>
-    <%= link_to("Post to COVE", "#", class: "btn btn-default btn-sm", disabled: "disabled", role: "button") %>
-    <%= link_to("Post to Github", "#", class: "btn btn-default btn-sm", disabled: "disabled", role: "button") %>
+    <%= link_to("Copy to COVE Editions", document_post_to_cove_path(@document), class: "btn btn-default btn-sm", role: "button") %>
+    <% if @document.cove_uri.present? %>
+      <%= link_to("View in COVE Editions", @document.cove_uri, target: "cove-edition", class: "btn btn-default btn-sm", role: "button") %>
+    <% end %>
   </div><!--/col-md-2 -->
 </div><!--/row -->
 <%= render "documents/help" %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -23,12 +23,12 @@
             <li class="list-group-item">
               <%= link_to document.title, document_path(document.friendly_id) %>
               <span class="pull-right">
-				  <% if document.rep_group_list.length > 0 %>
+          <% if document.rep_group_list.length > 0 %>
               <span class="label label-info">
                 <%= document.rep_group_list[0] %></span>
               <% end %>
                 <%= document.created_at.strftime("%m/%d/%Y") %></span>
-				<div class="clearfix"></div>
+        <div class="clearfix"></div>
             </li>
             <% end %>
             <li class="list-group-item"><em><a href="/documents?docs=assigned">See more shared documents&hellip;</a></em></li>
@@ -65,47 +65,47 @@
       </ul>
     </div><!--/ panel -->
 
-	  <div class="panel panel-default" id="dashboard-groups">
-		  <div class="panel-heading">
+    <div class="panel panel-default" id="dashboard-groups">
+      <div class="panel-heading">
         <span class="panel-title">
           <%= link_to ENV["CLASS_TERM_PLURAL"], groups_path %></span>
-			  <ul class="nav nav-tabs nav-tabs-xs pull-right" id="group-tabs" role="tablist">
-				  <li>
-					  <a href="#subgroups" data-toggle="tab">
-						  <span class="badge"><%= current_user.rep_subgroup_list.size %></span> <%= ENV["GROUP_TERM_PLURAL"] %>
-					  </a>
-				  </li>
-				  <li class="active">
-					  <a href="#groups" data-toggle="tab">
-						  <span class="badge"><%= current_user.rep_group_list.size %></span> <%= ENV["CLASS_TERM_PLURAL"] %>
-					  </a>
-				  </li>
-			  </ul>
-		  </div>
-		  <!-- / .panel-heading -->
+        <ul class="nav nav-tabs nav-tabs-xs pull-right" id="group-tabs" role="tablist">
+          <li>
+            <a href="#subgroups" data-toggle="tab">
+              <span class="badge"><%= current_user.rep_subgroup_list.size %></span> <%= ENV["GROUP_TERM_PLURAL"] %>
+            </a>
+          </li>
+          <li class="active">
+            <a href="#groups" data-toggle="tab">
+              <span class="badge"><%= current_user.rep_group_list.size %></span> <%= ENV["CLASS_TERM_PLURAL"] %>
+            </a>
+          </li>
+        </ul>
+      </div>
+      <!-- / .panel-heading -->
 
-		  <div class="tab-content">
-			  <div class="tab-pane no-padding fade in" id="subgroups">
-				  <ul class="list-group">
-					  <% current_user.rep_subgroup_list.each do |group| %>
-						  <li class="list-group-item"><%= group %></li>
-					  <% end %>
-				  </ul>
-			  </div>
-			  <div class="tab-pane no-padding fade active in" id="groups">
-				  <ul class="list-group">
-					  <% current_user.rep_group_list.each do |group| %>
-						  <li class="list-group-item"><%= group %></li>
-					  <% end %>
-				  </ul>
-			  </div>
-		  </div>
-		  <!--<ul class="nav nav-pills">-->
-		  <!--<li>-->
-		  <!--<%#= link_to "Go to class and group list", groups_path %>-->
-		  <!--</li>-->
-		  <!--</ul>-->
-	  </div><!--/ panel -->
+      <div class="tab-content">
+        <div class="tab-pane no-padding fade in" id="subgroups">
+          <ul class="list-group">
+            <% current_user.rep_subgroup_list.each do |group| %>
+              <li class="list-group-item"><%= group %></li>
+            <% end %>
+          </ul>
+        </div>
+        <div class="tab-pane no-padding fade active in" id="groups">
+          <ul class="list-group">
+            <% current_user.rep_group_list.each do |group| %>
+              <li class="list-group-item"><%= group %></li>
+            <% end %>
+          </ul>
+        </div>
+      </div>
+      <!--<ul class="nav nav-pills">-->
+      <!--<li>-->
+      <!--<%#= link_to "Go to class and group list", groups_path %>-->
+      <!--</li>-->
+      <!--</ul>-->
+    </div><!--/ panel -->
 
   </div><!--/ col-md-6 -->
   <div class="col-md-6">
@@ -148,7 +148,7 @@
       </div>
       <!--<ul class="nav nav-pills">-->
         <!--<li>-->
-		<!--  <%#= link_to "Go to annotation list", annotations_path %></li>-->
+    <!--  <%#= link_to "Go to annotation list", annotations_path %></li>-->
       <!--</ul>-->
     </div>
     <!--/ panel --> </div>
@@ -200,10 +200,10 @@ jQuery(function ($) {
 
 </script>
 <script type="text/template" id="user-comment-template">
-	<span class="user-highlight"><span class="pull-right">{{formattedDate}}</span><div class="ellipsis"><a href="{{uri}}#hl{{uuid}}">{{{quote}}}</a></div></span>
+  <span class="user-highlight"><span class="pull-right">{{formattedDate}}</span><div class="ellipsis"><a href="{{uri}}#hl{{uuid}}">{{{quote}}}</a></div></span>
   <span class="user-comment"><div class="ellipsis">{{{text}}}</div><div class="secondary-text">{{title}} ({{username}})</div></span>
 </script>
 <script type="text/template" id="user-highlight-template">
   <span class="user-highlight"><div class="ellipsis"><a href="{{uri}}#hl{{uuid}}">{{{quote}}}</a></div></span>
-	<span class="user-comment"><div class="secondary-text">{{title}} ({{username}})</div></span>
+  <span class="user-comment"><div class="secondary-text">{{title}} ({{username}})</div></span>
 </script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,7 @@ AnnotationStudio::Application.routes.draw do
     post :snapshot
     get :export
     get :preview, to: 'documents#preview'
+    get :post_to_cove, to: 'documents#post_to_cove'
   end
 
   resources :users, only: [:show, :edit]

--- a/db/migrate/20161018191136_add_cove_uri_to_documents.rb
+++ b/db/migrate/20161018191136_add_cove_uri_to_documents.rb
@@ -1,0 +1,5 @@
+class AddCoveUriToDocuments < ActiveRecord::Migration
+  def change
+    add_column :documents, :cove_uri, :string
+  end
+end

--- a/db/migrate/20161018195535_add_cove_info_to_users.rb
+++ b/db/migrate/20161018195535_add_cove_info_to_users.rb
@@ -1,0 +1,6 @@
+class AddCoveInfoToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :cove_id, :integer
+    add_column :users, :full_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160912201159) do
+ActiveRecord::Schema.define(version: 20161018195535) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -105,6 +105,7 @@ ActiveRecord::Schema.define(version: 20160912201159) do
     t.string   "survey_link",         limit: 255
     t.text     "default_state"
     t.text     "snapshot"
+    t.string   "cove_uri"
   end
 
   add_index "documents", ["slug"], name: "index_documents_on_slug", unique: true, using: :btree
@@ -239,6 +240,8 @@ ActiveRecord::Schema.define(version: 20160912201159) do
     t.boolean  "agreement"
     t.string   "provider"
     t.string   "uid"
+    t.integer  "cove_id"
+    t.string   "full_name"
   end
 
   add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree

--- a/lib/api_requester.rb
+++ b/lib/api_requester.rb
@@ -1,46 +1,131 @@
 require 'net/http'
 require 'multi_json'
+require "rest-client"
 require 'csv'
+require "json"
 
 class ApiRequester
-	@@api_url = ENV['API_URL']
+    @@api_url = ENV['API_URL']
 
-	def self.search(params, token, to_csv: false)
-		url = URI.parse(@@api_url + '/search')
-		url.query = URI.encode_www_form(params)
-		request = Net::HTTP::Get.new(url)
-		# request['accept'] = 'application/json'
-		request['accept'] = 'text/csv'
-		request['x-annotator-auth-token'] = token
-		response = Net::HTTP.start(url.host, url.port) {|http| http.request(request)}
-		response.body
-		data = MultiJson.load(response.body)
-		to_csv == false ? data : CsvGenerator.to_csv(data)
-	end
+    def self.search(params, token, to_csv: false)
+        url = URI.parse(@@api_url + '/search')
+        url.query = URI.encode_www_form(params)
+        request = Net::HTTP::Get.new(url)
+        # request['accept'] = 'application/json'
+        request['accept'] = 'text/csv'
+        request['x-annotator-auth-token'] = token
+        response = Net::HTTP.start(url.host, url.port) {|http| http.request(request)}
+        response.body
+        data = MultiJson.load(response.body)
+        to_csv == false ? data : CsvGenerator.to_csv(data)
+    end
 
-	def self.field(params, token, to_csv: false)
-		url = URI.parse(@@api_url + '/field')
-		url.query = URI.encode_www_form(params)
-		request = Net::HTTP::Get.new(url)
-		request['accept'] = 'application/json'
-		request['x-annotator-auth-token'] = token
-		response = Net::HTTP.start(url.host, url.port) {|http| http.request(request)}
-		data = MultiJson.load(response.body)
-	end
+    def self.field(params, token, to_csv: false)
+        url = URI.parse(@@api_url + '/field')
+        url.query = URI.encode_www_form(params)
+        request = Net::HTTP::Get.new(url)
+        request['accept'] = 'application/json'
+        request['x-annotator-auth-token'] = token
+        response = Net::HTTP.start(url.host, url.port) {|http| http.request(request)}
+        data = MultiJson.load(response.body)
+    end
 
 end
 
-class CsvGenerator
-	@@fields = ['id', 'user', 'username', 'text', 'uri', 'quote', 
-				'tags', 'ranges', 'subgroups', 'groups', 'updated', 'created']
+class CoveClient
+    @@api_url = ENV['COVE_URL']
+    @@password = ENV['COVE_PASSWORD']
+    @@username = ENV['COVE_USERNAME']
+    @@login_url = "#@@api_url/editions/api/user/login"
+    @@action_url = "#@@api_url/editions/api/node"
+    @@token_url = "#@@api_url/services/session/token"
 
-	def self.to_csv(data)
-		csv_string = CSV.generate do |csv|
-			csv << @@fields
-			data.each do |hash|
-				csv << hash.values_at(*@@fields)
-			end
-		end
-		csv_string
-	end
+    def self.get_unauth_session
+        headers = {
+          accept: :json,
+          content_type: 'application/json',
+        }
+
+        response = RestClient.get(@@token_url, headers)
+        case response.code
+        when 200
+            puts "unAuth Request successful."
+        else
+            puts "unAuth Request unsuccessful."
+        end
+        return response.body    
+    end
+
+    def self.get_cookie(token)
+        params = {
+          'username': @@username,
+          'password': @@password
+        }
+        headers = {
+          'X-CSRF-Token': token,
+          accept: :json,
+          content_type: 'application/json',
+        }
+        response = RestClient.post(@@login_url, params, headers)
+        cookies = response.cookies
+        case response.code
+        when 200
+            puts "Cookie Request successful"
+            return cookies
+        else
+            puts "Cookie Request not successful"
+        end
+    end
+
+
+    def self.get_login_session(cookie)
+        headers = {
+          cookies: cookie,
+          accept: :json,
+          content_type: 'application/json',
+        }
+
+        response = RestClient.get(@@token_url, headers)
+
+        case response.code
+        when 200
+            puts "Login GET Request successful"
+        else
+            puts "Login GET Request not successful"
+        end
+        return response.body    
+    end
+
+
+    def self.post(token, cookies, document)
+        headers = {
+          accept: :json,
+          content_type: 'application/json',
+          'X-CSRF-Token': token,
+          'cookies': cookies
+        }
+        response = RestClient.post(@@action_url, document.to_json, headers)
+        case response.code
+        when 200
+            puts "POST Request successful"
+        else
+            puts "POST Request not successful"
+        end
+        return response.body
+    end
+end
+
+class CsvGenerator
+    @@fields = ['id', 'user', 'username', 'text', 'uri', 'quote', 
+                'tags', 'ranges', 'subgroups', 'groups', 'updated', 'created']
+
+    def self.to_csv(data)
+        csv_string = CSV.generate do |csv|
+            csv << @@fields
+            data.each do |hash|
+                csv << hash.values_at(*@@fields)
+            end
+        end
+        csv_string
+    end
 end

--- a/lib/tasks/ingester.rake
+++ b/lib/tasks/ingester.rake
@@ -1,0 +1,79 @@
+namespace :ingest do
+  desc "Ingest all documents from COVE"
+  task :documents => :environment do
+    
+    # get all documents
+    documents = ApiRequester::DocumentIngester.get_documents
+    
+    # For each document
+    documents.each do |document|
+      # - Look up or create the owner user, by email address
+      # - Include: email address, cove_id, full name
+      owner = User.find_or_initialize_by(email: document["mail"])
+      owner.full_name = document["user"]
+      owner.cove_id = document["uid"]
+      owner.agreement = true
+      puts owner.to_json
+      # owner.save
+
+      # - Create the document
+      document = Document.find_or_initialize_by(cove_uri: document["uri"])
+
+      # - Assign to the user
+      document.user_id = owner.id
+      document.title = document["title"]
+      document.text = document["body"]
+
+      # document.cove_uri = document["uri"]
+      # - Save the document, including: title, body, user_id, cove_uri
+      puts document.to_json
+      # document.save
+      puts "=========="
+    end
+  end
+
+  desc "Ingest all annotations from COVE"
+  task :annotations => :environment do
+    
+    # Get all annotations from COVE
+    # - Receive an array of JSON objects, each one an annotation
+    annotations = ApiRequester::AnnotationIngester.get_annotations
+    
+    # For each annotation
+    # - Map categories values to COVE Studio id values
+    #   - Harvest all category strings, look up or create each in AS
+    #   - Replace text in the annotation JSON with id values from AS JF
+    # - Flatten URI field
+    #   - Get COVE URI value from nested object
+    #   - Look up AS document by COVE URI
+    #   - Rewrite value of uri from nested object to string JF
+    # - Change annotation_tags to tags
+    #   - Change key name
+    #   - Replace nested tag object with array of strings
+    # - POST annotation to MIT API
+    annotations.each do |annotation|
+      #   - Look up user from AS by COVE ID
+      #   - Insert user email from AS user object into annotation
+      #   - Flatten user object to email
+      owner = User.find_or_initialize_by(email: annotation["mail"])
+      owner.cove_id = annotation["uid"]
+      owner.agreement = true
+      puts owner.to_json
+      # owner.save
+
+      # - Create the document
+      document = Document.find_or_initialize_by(cove_uri: annotation["uri"])
+
+      # - Assign to the user
+      document.user_id = owner.id
+      document.title = annotation["title"]
+      document.text = annotation["body"]
+
+      # document.cove_uri = annotation["uri"]
+      # - Save the document, including: title, body, user_id, cove_uri
+      puts document.to_json
+      # document.save
+      puts "=========="
+    end
+  end
+end


### PR DESCRIPTION
### What this PR does
You can now push an annotated document from COVE Studio (Annotation Studio) to COVE Editions (Drupal CMS-backed public site for COVE).

Closes #30, closes #4 

### Steps to test
1. Log into the [review app](http://cove-staging-pr-83.herokuapp.com/).
1. Annotate a document
1. Open the tools sidebar, scroll to the bottom, click snapshot, then click preview. You should see your annotated document. 
1. Click "Copy to COVE Editions"
1. You should be redirected to the document page, where the success message provides a link to see an XML version of the object created in COVE Editions.

### To Do
Once the COVE Editions site returns a URL to the HTML rendered version of the document, the link will point there instead.
