### PR TITLE
downcase email in oauth check

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -44,7 +44,7 @@ class User < ActiveRecord::Base
   end
 
   def self.find_for_wordpress_oauth2(auth, current)
-    authed_user = User.where(email: auth.info.email).first_or_initialize do |user|
+    authed_user = User.where(email: auth.info.email.downcase).first_or_initialize do |user|
       user.firstname = auth.info.name.split(' ').first
       user.lastname = auth.info.name.split(' ').length > 1 ? auth.info.name.split(' ').last : " "
       user.agreement = true


### PR DESCRIPTION
### What does this PR do?
Prevents a case in which a user whose email as registered with NAVSA contained uppercase characters would receive a server error when logging in after initial account creation — the email address as automatically downcased by Devise would fail to match with the address as stored in the authentication hash, leading to the creation of a new user record that would be rejected during save for email address collision. 

### What issues does it address?
Closes #121 

### How to test
Sign in to NAVSA.org, then go to [COVE Studio staging](http://cove-staging.herokuapp.com/) and click Log in -> Log in through NAVSA. This should log you in successfully. Log out, return to NAVSA and edit your profile there to switch a few letters in your email address to uppercase. Save and re-login to COVE Studio staging. This should log you into the same account as before.