### PR TITLE
Made class term configurable on document form.

### DIFF
--- a/app/views/documents/_form.html.erb
+++ b/app/views/documents/_form.html.erb
@@ -54,14 +54,14 @@
                   <i class="glyphicon glyphicon-pencil"></i> Editable
                   <p class="help-block">privately visible, not annotatable</p>
                   </label>
-                </div>  
+                </div>
                 <div class="radio">
                   <label>
                   <%= f.radio_button :state, "annotatable", checked: @document.annotatable? %>
                   <i class="glyphicon glyphicon-comment"></i> Annotatable
                   <p class="help-block">privately annotatable, privately visible, not editable</p>
                   </label>
-                </div>  
+                </div>
                 <% if can? :review, Document %>
                 <div class="radio">
                   <label>
@@ -69,7 +69,7 @@
                   <i class="glyphicon glyphicon-eye-open"></i> Reviewable
                   <p class="help-block">privately annotatable, publicly visible, not editable</p>
                   </label>
-                </div>  
+                </div>
                 <% end %>
                 <% if can? :publish, Document %>
                 <div class="radio">
@@ -78,16 +78,16 @@
                   <i class="glyphicon glyphicon-book"></i> Publishable
                   <p class="help-block">not annotatable, publicly visible, not editable</p>
                   </label>
-                </div>  
+                </div>
                 <% end %>
           	</div>
 				  </div><!-- end span 6 -->
 
 			  <div class="col-md-6">
-          	<h4><%= ENV["CLASS_TERM"] %></h4>
-          	<p class="help-block">Enter the classes to whom you wish to assign this document, <strong>and press enter after each.</strong></p>
+          	<h4><%= ENV["CLASS_TERM_PLURAL"] %></h4>
+          	<p class="help-block">Enter the <%= ENV["CLASS_TERM_PLURAL"] %> to which you wish to assign this document, <strong>and press enter after each.</strong></p>
           	<div class="form-group">
-          	<%= f.text_field :rep_group_list, :value => @document.rep_group_list.join(', '), :class => 'form-control', 'data-role' => "tagsinput", 'placeholder' => "Enter class name(s)" %>
+          	<%= f.text_field :rep_group_list, :value => @document.rep_group_list.join(', '), :class => 'form-control', 'data-role' => "tagsinput", 'placeholder' => ENV["CLASS_TERM_PLURAL"] %>
           	</div>
 			  </div><!-- end span 6 -->
 			  </div><!-- end row -->


### PR DESCRIPTION
### What this PR Does

Closes #135, which incorrectly didn't use the config value for the CLASS_TERM to set the placeholder in a form field.

### How to test

1. Go to: https://cove-staging-pr-136.herokuapp.com/
2. Log in
3. Go to the new document form: http://cove-staging-pr-136.herokuapp.com/documents/new
4. Note that the placeholder text in the "Editions" field at bottom right is "Editions".
5. Change the config (ask Jamie to do this -- not yet an end user feature)
6. Note that the placeholder is now different.

