### PR TITLE
WIP: Add guidance for banner size

### DIFF
--- a/app/controllers/anthologies_controller.rb
+++ b/app/controllers/anthologies_controller.rb
@@ -5,6 +5,11 @@ class AnthologiesController < ApplicationController
     Rails.logger.info Anthology.all.inspect
     Rails.logger.info @anthology.inspect
     @anthologies = Anthology.all
+    @search_documents_count = @anthology.documents.count
+    document_set = 'all'
+    total_pages = 1
+    @tab_state = { document_set => 'active' }
+    @documents = @anthology.documents.paginate(:page => 1, :per_page =>1 )
   end
 
   def create
@@ -63,7 +68,7 @@ class AnthologiesController < ApplicationController
         format.html { redirect_to anthologies_url, notice: 'Anthology was successfully updated.' }
         format.json { head :no_content }
       else
-        format.html { render action: "edit" }
+        format.html { redirect_to edit_anthology_url(id: @anthology.friendly_id), alert: @anthology.error_messages}
         format.json { render json: @anthology.errors, status: :unprocessable_entity }
       end
     end

--- a/app/models/anthology.rb
+++ b/app/models/anthology.rb
@@ -6,9 +6,33 @@ class Anthology < ActiveRecord::Base
     medium: ["1100x250>", :jpg],
   }
   validates_attachment_content_type :banner, :content_type => ["image/jpg", "image/jpeg", "image/png", "image/gif"]
-  validates_with AttachmentSizeValidator, attributes: :banner, less_than: 1.megabytes
+  validate :check_content_type
+  validate :check_file_size
   has_and_belongs_to_many :users, join_table: 'users_anthologies'
   belongs_to :user
   friendly_id :name, use: :slugged
   belongs_to :user
+  attr_accessor :error_messages
+
+  def check_content_type
+    if !['image/jpg', 'image/jpeg', 'image/gif','image/png'].include?(self.banner_content_type)
+      errors.add(:banner, "File '#{self.banner_file_name}' is not a valid image type")
+      unless self.error_messages
+      self.error_messages =  "File '#{self.banner_file_name}' is not a valid image type"
+      else
+        self.error_messages =  "#{self.error_messages} and File '#{self.banner_file_name}' is not a valid image type"
+      end
+    end
+  end
+
+  def check_file_size
+    if !( self.banner_file_size < 1.megabytes )
+      errors.add(:banner, "File is too big")
+      unless self.error_messages
+      self.error_messages =  "File '#{self.banner_file_name}' should be less than 1 MB"
+      else
+        self.error_messages =  "#{self.error_messages} and File '#{self.banner_file_name}' should be less than 1 MB"
+      end
+    end
+  end
 end

--- a/app/models/anthology.rb
+++ b/app/models/anthology.rb
@@ -3,11 +3,10 @@ class Anthology < ActiveRecord::Base
   has_and_belongs_to_many :documents
   has_attached_file :banner,
                      styles: {
-    medium: ["3000x420>", :jpg],
-    small: ["1000x96>", :jpg],
-    thumb: ["800x45#", :jpg]
+    medium: ["1100x250>", :jpg],
   }
   validates_attachment_content_type :banner, :content_type => ["image/jpg", "image/jpeg", "image/png", "image/gif"]
+  validates_with AttachmentSizeValidator, attributes: :banner, less_than: 1.megabytes
   has_and_belongs_to_many :users, join_table: 'users_anthologies'
   belongs_to :user
   friendly_id :name, use: :slugged

--- a/app/views/anthologies/_form.html.erb
+++ b/app/views/anthologies/_form.html.erb
@@ -13,7 +13,7 @@
         <div class="form-group">
           <%= f.label :banner %>
           <%= f.file_field :banner, class: 'form-control' %>
-        <i>The banner will be 3000 x 420 pixels </i>
+        <i>The banner should be a png, jpg, or jpeg and should be less than 1 MB</i>
         </div>
         <div class="form-group">
           <%= f.submit nil, :class => 'btn btn-default btn btn-default-primary btn-primary' %>

--- a/app/views/anthologies/_form.html.erb
+++ b/app/views/anthologies/_form.html.erb
@@ -13,6 +13,7 @@
         <div class="form-group">
           <%= f.label :banner %>
           <%= f.file_field :banner, class: 'form-control' %>
+        <i>The banner will be 3000 x 420 pixels </i>
         </div>
         <div class="form-group">
           <%= f.submit nil, :class => 'btn btn-default btn btn-default-primary btn-primary' %>

--- a/app/views/anthologies/_form.html.erb
+++ b/app/views/anthologies/_form.html.erb
@@ -13,7 +13,7 @@
         <div class="form-group">
           <%= f.label :banner %>
           <%= f.file_field :banner, class: 'form-control' %>
-        <i>The banner should be a png, jpg, or jpeg and should be less than 1 MB</i>
+        <i>The banner should be a png, jpg, or jpeg and should be less than 1 MB and at least 1100 # 250 pixels</i>
         </div>
         <div class="form-group">
           <%= f.submit nil, :class => 'btn btn-default btn btn-default-primary btn-primary' %>

--- a/app/views/anthologies/show.html.erb
+++ b/app/views/anthologies/show.html.erb
@@ -15,10 +15,10 @@
       <% else %>
         <div class="container" ><i> There is no description for this anthology.</i></div>
       <% end %>
-      <div class="media-left">
+      <div class="media-left" >
         <% unless @anthology.banner.blank? %>
 <div class="container" >
-          <%= link_to image_tag(@anthology.banner.url(:medium), class: 'media-object'), @anthology.banner.url(:medium), target: '_blank' %>
+          <%= link_to image_tag(@anthology.banner.url(:medium), class: 'media-object', style: "padding-top:15px;"), @anthology.banner.url(:medium), target: '_blank'  %>
 </div>
         <% end %>
       </div>

--- a/app/views/anthologies/show.html.erb
+++ b/app/views/anthologies/show.html.erb
@@ -17,8 +17,9 @@
       <% end %>
       <div class="media-left">
         <% unless @anthology.banner.blank? %>
-
+<div class="container" >
           <%= link_to image_tag(@anthology.banner.url(:medium), class: 'media-object'), @anthology.banner.url(:medium), target: '_blank' %>
+</div>
         <% end %>
       </div>
       <% unless @anthology.documents.count == 0 %>

--- a/app/views/anthologies/show.html.erb
+++ b/app/views/anthologies/show.html.erb
@@ -17,6 +17,7 @@
       <% end %>
       <div class="media-left">
         <% unless @anthology.banner.blank? %>
+
           <%= link_to image_tag(@anthology.banner.url(:medium), class: 'media-object'), @anthology.banner.url(:medium), target: '_blank' %>
         <% end %>
       </div>


### PR DESCRIPTION
### What does this PR do?

Makes it easy for users to add image banners to Anthologies which are of the correct type and size.

Closes #169

### For testing
1. Go to http://cove-staging.herokuapp.com/anthologies/literature-201-section-b
2. See if the whitespace for the banner looks good
3. Go to http://cove-staging.herokuapp.com/anthologies/literature-201-section-b/edit and see if the guidance looks good under the banner upload
4. try to upload an image that is jpg under  1 MB (on the banner upload part) and see if everything is working
5. try to upload an image that is jpg more than  1 MB (on the banner upload part) and see if an appropriate validation error comes up
6. try to upload a .doc file and see if a content file type error comes up
