### PR TITLE
Implemented document search on the anthology show page

### DIFF
--- a/app/controllers/anthologies_controller.rb
+++ b/app/controllers/anthologies_controller.rb
@@ -1,5 +1,6 @@
 class AnthologiesController < ApplicationController
   before_filter :find_anthology, :only => [:show, :edit]
+  before_filter :authenticate_user!
 
   def show
     @page = 1

--- a/app/controllers/anthologies_controller.rb
+++ b/app/controllers/anthologies_controller.rb
@@ -5,6 +5,11 @@ class AnthologiesController < ApplicationController
     Rails.logger.info Anthology.all.inspect
     Rails.logger.info @anthology.inspect
     @anthologies = Anthology.all
+    @search_documents_count = @anthology.documents.count
+    document_set = 'all'
+    total_pages = 1
+    @tab_state = { document_set => 'active' }
+    @documents = @anthology.documents.paginate(:page => 1, :per_page =>1 )
   end
 
   def create
@@ -63,7 +68,7 @@ class AnthologiesController < ApplicationController
         format.html { redirect_to anthologies_url, notice: 'Anthology was successfully updated.' }
         format.json { head :no_content }
       else
-        format.html { render action: "edit" }
+        format.html { redirect_to edit_anthology_url(id: @anthology.friendly_id), alert: @anthology.error_messages}
         format.json { render json: @anthology.errors, status: :unprocessable_entity }
       end
     end

--- a/app/models/anthology.rb
+++ b/app/models/anthology.rb
@@ -6,9 +6,33 @@ class Anthology < ActiveRecord::Base
     medium: ["1100x250>", :jpg],
   }
   validates_attachment_content_type :banner, :content_type => ["image/jpg", "image/jpeg", "image/png", "image/gif"]
-  validates_with AttachmentSizeValidator, attributes: :banner, less_than: 1.megabytes
+  validate :check_content_type
+  validate :check_file_size
   has_and_belongs_to_many :users, join_table: 'users_anthologies'
   belongs_to :user
   friendly_id :name, use: :slugged
   belongs_to :user
+  attr_accessor :error_messages
+
+  def check_content_type
+    if !['image/jpg', 'image/jpeg', 'image/gif','image/png'].include?(self.banner_content_type)
+      errors.add(:banner, "File '#{self.banner_file_name}' is not a valid image type")
+      unless self.error_messages
+      self.error_messages =  "File '#{self.banner_file_name}' is not a valid image type"
+      else
+        self.error_messages =  "#{self.error_messages} and File '#{self.banner_file_name}' is not a valid image type"
+      end
+    end
+  end
+
+  def check_file_size
+    if !( self.banner_file_size < 1.megabytes )
+      errors.add(:banner, "File is too big")
+      unless self.error_messages
+      self.error_messages =  "File '#{self.banner_file_name}' should be less than 1 MB"
+      else
+        self.error_messages =  "#{self.error_messages} and File '#{self.banner_file_name}' should be less than 1 MB"
+      end
+    end
+  end
 end

--- a/app/models/anthology.rb
+++ b/app/models/anthology.rb
@@ -3,11 +3,10 @@ class Anthology < ActiveRecord::Base
   has_and_belongs_to_many :documents
   has_attached_file :banner,
                      styles: {
-    medium: ["3000x420>", :jpg],
-    small: ["1000x96>", :jpg],
-    thumb: ["800x45#", :jpg]
+    medium: ["1100x250>", :jpg],
   }
   validates_attachment_content_type :banner, :content_type => ["image/jpg", "image/jpeg", "image/png", "image/gif"]
+  validates_with AttachmentSizeValidator, attributes: :banner, less_than: 1.megabytes
   has_and_belongs_to_many :users, join_table: 'users_anthologies'
   belongs_to :user
   friendly_id :name, use: :slugged

--- a/app/views/anthologies/_form.html.erb
+++ b/app/views/anthologies/_form.html.erb
@@ -13,7 +13,7 @@
         <div class="form-group">
           <%= f.label :banner %>
           <%= f.file_field :banner, class: 'form-control' %>
-        <i>The banner will be 3000 x 420 pixels </i>
+        <i>The banner should be a png, jpg, or jpeg and should be less than 1 MB</i>
         </div>
         <div class="form-group">
           <%= f.submit nil, :class => 'btn btn-default btn btn-default-primary btn-primary' %>

--- a/app/views/anthologies/_form.html.erb
+++ b/app/views/anthologies/_form.html.erb
@@ -13,6 +13,7 @@
         <div class="form-group">
           <%= f.label :banner %>
           <%= f.file_field :banner, class: 'form-control' %>
+        <i>The banner will be 3000 x 420 pixels </i>
         </div>
         <div class="form-group">
           <%= f.submit nil, :class => 'btn btn-default btn btn-default-primary btn-primary' %>

--- a/app/views/anthologies/_form.html.erb
+++ b/app/views/anthologies/_form.html.erb
@@ -13,7 +13,7 @@
         <div class="form-group">
           <%= f.label :banner %>
           <%= f.file_field :banner, class: 'form-control' %>
-        <i>The banner should be a png, jpg, or jpeg and should be less than 1 MB</i>
+        <i>The banner should be a png, jpg, or jpeg and should be less than 1 MB and at least 1100 # 250 pixels</i>
         </div>
         <div class="form-group">
           <%= f.submit nil, :class => 'btn btn-default btn btn-default-primary btn-primary' %>

--- a/app/views/anthologies/show.html.erb
+++ b/app/views/anthologies/show.html.erb
@@ -15,10 +15,10 @@
       <% else %>
         <div class="container" ><i> There is no description for this anthology.</i></div>
       <% end %>
-      <div class="media-left">
+      <div class="media-left" >
         <% unless @anthology.banner.blank? %>
 <div class="container" >
-          <%= link_to image_tag(@anthology.banner.url(:medium), class: 'media-object'), @anthology.banner.url(:medium), target: '_blank' %>
+          <%= link_to image_tag(@anthology.banner.url(:medium), class: 'media-object', style: "padding-top:15px;"), @anthology.banner.url(:medium), target: '_blank'  %>
 </div>
         <% end %>
       </div>

--- a/app/views/anthologies/show.html.erb
+++ b/app/views/anthologies/show.html.erb
@@ -7,33 +7,95 @@
       </div>
       <% unless @anthology.description.blank? %>
         <div class="container" >
-        <h3>Description</h3>
-        <div class="container" >
-          <%= @anthology.description %>
-        </div>
+          <h3>Description</h3>
+          <div class="container" >
+            <%= @anthology.description %>
+          </div>
         </div>
       <% else %>
         <div class="container" ><i> There is no description for this anthology.</i></div>
       <% end %>
       <div class="media-left" >
         <% unless @anthology.banner.blank? %>
-<div class="container" >
-          <%= link_to image_tag(@anthology.banner.url(:medium), class: 'media-object', style: "padding-top:15px;"), @anthology.banner.url(:medium), target: '_blank'  %>
-</div>
+          <div class="container" >
+            <%= link_to image_tag(@anthology.banner.url(:medium), class: 'media-object', style: "padding-top:15px;"), @anthology.banner.url(:medium), target: '_blank'  %>
+          </div>
         <% end %>
       </div>
-      <% unless @anthology.documents.count == 0 %>
-        <div class="container" >
-          <h3>Documents</h3>
-          <% if params[:order].present? %>
-          <%= render partial: 'documents/document_table', locals: { documents: @anthology.documents.order(params[:order]) } %>
-        <% else %>
-          <%= render partial: 'documents/document_table', locals: { documents: @anthology.documents.order(:title) } %>
-        <% end %>
+      <div class="container">
+        <div class="row">
+          <%= form_tag(anthology_path(id: @anthology.friendly_id, docs: "search_results"), :method => "get", class: 'navbar-form navbar-left') do %>
+            <div class="input-group form-group">
+              <%= search_field_tag :title, params[:title], placeholder: "Title", class: "form-control" %>
+              <div class="input-group-btn">
+                <%= button_tag "Search", :class => 'btn btn-info',:name => nil%>
+              </div>
+            </div>
+          <% end %>
+          <%= form_tag(anthology_path(id: @anthology.friendly_id, docs: "search_results"), :method => "get", class: 'navbar-form navbar-left') do %>
+            <div class="input-group">
+              <%= search_field_tag :author, params[:author], placeholder: "Author", class: "form-control" %>
+              <div class="input-group-btn">
+                <%= button_tag "Search", :class => 'btn btn-info',:name => nil%>
+              </div>
+            </div>
+          <% end %>
+          <%= form_tag(anthology_path(id: @anthology.friendly_id, docs: "search_results"), :method => "get", class: 'navbar-form navbar-left') do %>
+            <div class="input-group">
+              <%= search_field_tag :edition, params[:edition], placeholder: "Edition", class: "form-control" %>
+              <div class="input-group-btn">
+                <%= button_tag "Search", :class => 'btn btn-info',:name => nil%>
+              </div>
+            </div>
+          <% end %>
         </div>
-      <% else %>
-        <div class="container" > There are no documents for this anthology. </div>
-      <% end %>
+      </div>
+      <div class="row">
+        <div class="col-md-12">
+          <div class="panel panel-default" id="dashboard-documents">
+            <div class="panel-heading">
+              <span class="panel-title">Documents</span>
+              <ul class="nav nav-tabs nav-tabs-xs pull-right" id="document-tabs" role="tablist">
+                <li class="<%= @tab_state['search_results'] %>">
+                  <%= link_to anthology_path( docs: 'search_results', title: params[:title],author: params[:author], edition: params[:edition], id: @anthology.friendly_id ), params do %>
+                    <span class='badge'><%= @search_documents_count %></span> Search Results
+                  <% end %>
+                </li>
+                <% if can? :manage, Document %>
+                  <li class="<%= @tab_state['all'] %>">
+                    <%= link_to anthology_path( docs: 'all', title: params[:title],author: params[:author], edition: params[:edition], id: @anthology.friendly_id ), params do %>
+                      <span class='badge'><%= @all_documents_count %></span> All
+                    <% end %>
+                  </li>
+                <% end %>
+              </ul>
+            </div>
+            <div class="tab-content">
+              <div class="tab-pane no-padding active" id="all">
+                <% unless @documents.blank? %>
+                  <%= form_tag(anthology_add_path(anthology: @anthology.id), :method => "post") do %>
+                    <%= render partial: 'documents/document_table', locals: { documents: @documents } %>
+                  <%= button_tag "Add selected to anthology", :class => 'btn btn-primary create-new-button',:name => nil%>
+              <% end %>
+                <% else %>
+                  <div class="container">
+                    <tr>
+                      <td colspan="6">No documents to view.</td>
+                    </tr>
+                  </div>
+                <% end %>
+              </div>
+            </div>
+            <div class="panel-footer doc-set-footer">
+              <% if @documents.present? && @documents.count > 0 %>
+                <div class='pagination-controls'>
+                  <%= will_paginate @documents, renderer: BootstrapPagination::Rails %>
+                </div>
+              <% end %>
+            </div>
+          </div><!--/panel -->
+        </div><!--/col-md-12 -->
+      </div>
     </div>
   </div><!--/panel-body -->
 </div><!--/panel -->

--- a/app/views/anthologies/show.html.erb
+++ b/app/views/anthologies/show.html.erb
@@ -17,8 +17,9 @@
       <% end %>
       <div class="media-left">
         <% unless @anthology.banner.blank? %>
-
+<div class="container" >
           <%= link_to image_tag(@anthology.banner.url(:medium), class: 'media-object'), @anthology.banner.url(:medium), target: '_blank' %>
+</div>
         <% end %>
       </div>
       <% unless @anthology.documents.count == 0 %>

--- a/app/views/anthologies/show.html.erb
+++ b/app/views/anthologies/show.html.erb
@@ -17,6 +17,7 @@
       <% end %>
       <div class="media-left">
         <% unless @anthology.banner.blank? %>
+
           <%= link_to image_tag(@anthology.banner.url(:medium), class: 'media-object'), @anthology.banner.url(:medium), target: '_blank' %>
         <% end %>
       </div>

--- a/app/views/documents/_document_table.html.erb
+++ b/app/views/documents/_document_table.html.erb
@@ -1,30 +1,22 @@
 <table class="table table-striped table-bordered">
   <tr>
-    <% unless controller_name == "anthologies" %>
       <th></th>
       <th><%= link_to "Title", documents_path( order: "title", docs: params[:docs], title: params[:title],author: params[:author], edition: params[:edition], anthology_id: params[:anthology_id] ) %>
       </th>
       <th><%= link_to "Author", documents_path( order: "author", docs: params[:docs], title: params[:title],author: params[:author], edition: params[:edition], anthology_id: params[:anthology_id] ) %>
       </th>
       <th><%= link_to "Created", documents_path( order: "created_at", docs: params[:docs], title: params[:title],author: params[:author], edition: params[:edition], anthology_id: params[:anthology_id] ) %>    </th>
-  <% else %>
-    <th><%= link_to "Title", anthology_path(friendly_id: @anthology.friendly_id, order: "title") %></th>
-    <th><%= link_to "Author", anthology_path(friendly_id: @anthology.friendly_id, order: "author") %></th>
-    <th><%= link_to "Created", anthology_path(friendly_id: @anthology.friendly_id, order: "created_at") %></th>
-    <% end %>
     <th><%= ENV["CLASS_TERM_PLURAL"] %></th>
     <th>Status</th>
     <th>Actions</th>
   </tr>
   <% documents.each do |document| %>
     <tr>
-      <% unless controller_name == "anthologies" %>
         <% if document.anthologies.include?(@anthology) %>
           <td><div class="<%= "document_of_#{document.id}" %>" ><%= check_box_tag 'document_ids[]', document.id,  :checked => "checked" %></div></td>
         <% else %>
           <td><div class="<%= "document_of_#{document.id}"%>" ><%= check_box_tag 'document_ids[]',  document.id %></div></td>
         <% end %>
-      <% end %>
       <td>
         <% if controller_name == 'anthologies' %>
           <%= link_to document.title, anthology_document_path(@anthology.friendly_id, document.friendly_id) %></td>


### PR DESCRIPTION
# What this PR does
1. Allows users to search for documents (all documents) in the anthology show by author, edition, and title.
2. Allows users to see all the documents that belong to an anthology in the all tab of the anthology show
3. Allows users to add documents to an anthology 
4. Allows users to remove documents from an anthology if they are admins
3. Closes #207 
# Testing
1. Go to http://cove-staging.herokuapp.com/anthologies and select any anthology 
2. Search for a document by author, edition, or title
3. The search results tab should be active with your search results and pagination if there are more than 10 results
4. You can then try to remove a document from an anthology if it already is part of the anthology and see if you get a successful flash message after. (To see which documents are part of the anthology click the all tab)
5. Search for a document that is not a part of anthology and try to add it by checking the check box and clicking on add to anthology. You should then be given a successful flash message after which you will see the document in the all tab. As an example you can search for "Un" as the title.