### PR TITLE
Now users can search for users assigned to anthologies by email and full name

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -171,3 +171,13 @@ img#neh-logo {
     color: #fff;
   }
 }
+
+.anthology-description { 
+  margin-bottom: 15px;
+}
+
+.an-searched-users-table-header { 
+  margin-bottom: 20px;
+  font-size: 16px;
+  color: inherit;
+}

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -32,7 +32,7 @@ class Ability
       can :read, Document do |tors|
         !(user.rep_group_list & tors.rep_group_list).empty?
       end
-
+      cannot :manage, User
     else
       cannot :manage, :all
       can :read, Document, { :public? => true }

--- a/app/views/anthologies/_documents_tab.html.erb
+++ b/app/views/anthologies/_documents_tab.html.erb
@@ -1,0 +1,28 @@
+<div class="container tab-pane" id="documents-001">
+    <div class="row">
+        <%= form_tag(anthology_path(id: anthology.friendly_id, docs: "search_results"), :method => "get", class: 'navbar-form navbar-left') do %>
+            <div class="input-group form-group">
+              <%= search_field_tag :title, params[:title], placeholder: "Title", class: "form-control" %>
+              <div class="input-group-btn">
+                <%= button_tag "Search", :class => 'btn btn-info',:name => nil %>
+              </div>
+            </div>
+          <% end %>
+          <%= form_tag(anthology_path(id: anthology.friendly_id, docs: "search_results"), :method => "get", class: 'navbar-form navbar-left') do %>
+            <div class="input-group">
+              <%= search_field_tag :author, params[:author], placeholder: "Author", class: "form-control" %>
+              <div class="input-group-btn">
+                <%= button_tag "Search", :class => 'btn btn-info',:name => nil %>
+              </div>
+            </div>
+          <% end %>
+          <%= form_tag(anthology_path(id: anthology.friendly_id, docs: "search_results"), :method => "get", class: 'navbar-form navbar-left') do %>
+            <div class="input-group">
+              <%= search_field_tag :edition, params[:edition], placeholder: "Edition", class: "form-control" %>
+              <div class="input-group-btn">
+                <%= button_tag "Search", :class => 'btn btn-info',:name => nil %>
+              </div>
+            </div>
+          <% end %>
+        </div>
+      </div>

--- a/app/views/anthologies/_searched_documents.erb
+++ b/app/views/anthologies/_searched_documents.erb
@@ -1,0 +1,51 @@
+<div class="container">
+<div class="row">
+<div class="col-md-12">
+  <div class="panel panel-default" id="dashboard-documents">
+    <div class="panel-heading">
+      <span class="panel-title">Documents</span>
+      <ul class="nav nav-tabs nav-tabs-xs pull-right" id="document-tabs" role="tablist">
+        <li class="<%= tab_state['search_results'] %>">
+          <%= link_to anthology_path( docs: 'search_results', title: params[:title],author: params[:author], edition: params[:edition], id: anthology.friendly_id, tab: params[:tab] ), params do %>
+            <span class='badge'><%= search_documents_count %></span> Search Results
+          <% end %>
+        </li>
+        <% if can? :manage, Document %>
+          <li class="<%= tab_state['all'] %>">
+            <%= link_to anthology_path( docs: 'all', title: params[:title],author: params[:author], edition: params[:edition], id: anthology.friendly_id, tab: params[:tab] ), params do %>
+              <span class='badge'><%= all_documents_count %></span> All
+            <% end %>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+    <div class="tab-content">
+      <div class="tab-pane no-padding active" id="all">
+        <% unless documents.blank? %>
+          <%= form_tag(anthology_add_path(anthology: anthology.id), :method => "post") do %>
+            <%= render partial: 'documents/document_table', locals: { documents: documents } %>
+
+            <% if current_user.admin? || current_user.teacher? %>
+              <%= button_tag "Add selected to anthology", :class => 'btn btn-primary create-new-button',:name => nil%>
+            <% end %>
+      <% end %>
+        <% else %>
+          <div class="container">
+            <tr>
+              <td colspan="6">No documents to view.</td>
+            </tr>
+          </div>
+        <% end %>
+      </div>
+    </div>
+    <div class="panel-footer doc-set-footer">
+      <% if documents.present? && documents.count > 0 %>
+        <div class='pagination-controls'>
+          <%= will_paginate documents, renderer: BootstrapPagination::Rails %>
+        </div>
+      <% end %>
+    </div>
+  </div><!--/panel -->
+</div><!--/col-md-12 -->
+</div>
+</div>

--- a/app/views/anthologies/_searched_users.html.erb
+++ b/app/views/anthologies/_searched_users.html.erb
@@ -1,0 +1,47 @@
+<div class="container">
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <span class="an-searched-users-table-header">Users</span>
+                <ul class="nav nav-tabs nav-tabs-xs pull-right" id="document-tabs" role="tablist">
+                    <li class="<%= tab_state['search_results'] %>">
+                        <%= link_to anthology_path( docs: 'search_results', name: params[:name],email: params[:email], tab: params[:tab], id: anthology.friendly_id ), params do %>
+                            <span class='badge'><%= search_users_count %></span> Search Results
+                        <% end %>
+                    </li>
+                    <li class="<%= tab_state['all'] %>">
+                        <%= link_to anthology_path( docs: 'all', name: params[:name],email: params[:email], tab: params[:tab], id: anthology.friendly_id ), params do %>
+                            <span class='badge'><%= all_users_count %></span> All
+                        <% end %>
+                    </li>
+                </ul>
+            <% if users.count.zero? %>
+                <i> No users are assigned to this anthology </i>
+            <% else %>
+                <table class="table table-striped table-bordered">
+                    <thead>
+                        <tr>
+                            <th>Full Name</th>
+                            <th>Email</th>
+                            <th>Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <% users.each do |user| %>
+                            <tr>
+                                <td> <%= link_to "#{user.firstname} #{user.lastname}", user_path(user.id) %> </td>
+                                <td> <%= user.email %> </td>
+                                <td>
+                                    <% if anthology.users.include?(user) %>
+                                        <%= link_to 'Remove From Anthology', { action: :remove_user, controller: 'anthologies', anthology_id: anthology.id, user_id: user.id}, method: :post , :class => 'btn btn-danger btn-md' %>
+                                    <% else  %>
+                                        <%= link_to 'Assign To Anthology', { action: :add_user, controller: 'anthologies', anthology_id: anthology.id, user_id: user.id}, method: :post, :class => 'btn btn-primary btn-md' %>
+                                    <% end %>
+                                </td>
+                            </tr>
+                        <% end %>
+                    </tbody>
+                </table>
+            <% end %>
+        </div>
+    </div>
+</div>

--- a/app/views/anthologies/_users_tab.html.erb
+++ b/app/views/anthologies/_users_tab.html.erb
@@ -1,0 +1,23 @@
+<div class="container tab-pane" id="users-001">
+        <div class="row">
+          <%= form_tag(anthology_path(id: anthology.friendly_id, docs: "search_results"), :method => "get", class: 'navbar-form navbar-left') do %>
+            <div class="input-group form-group">
+              <%= search_field_tag :email, params[:email], placeholder: "Email", class: "form-control" %>
+              <%= hidden_field_tag :tab , "users" %>
+              <div class="input-group-btn">
+                <%= button_tag "Search", :class => 'btn btn-info',:name => nil %>
+              </div>
+            </div>
+          <% end %>
+
+          <%= form_tag(anthology_path(id: anthology.friendly_id, docs: "search_results"), :method => "get", class: 'navbar-form navbar-left') do %>
+            <div class="input-group">
+              <%= search_field_tag :name, params[:name], placeholder: "Full Name", class: "form-control" %>
+              <%= hidden_field_tag :tab , "users" %>
+              <div class="input-group-btn">
+                <%= button_tag "Search", :class => 'btn btn-info',:name => nil %>
+              </div>
+            </div>
+          <% end %>
+        </div>
+      </div>

--- a/app/views/anthologies/show.html.erb
+++ b/app/views/anthologies/show.html.erb
@@ -1,104 +1,69 @@
 <%= content_for :body_id, 'documents' %>
 <div class="row">
-  <div class="col-md-12">
-    <div class="panel panel-default" id="document-form">
-      <div class="panel-heading">
-        <span class="panel-title">Anthology: <%= @anthology.name %></span>
-      </div>
-      <% unless @anthology.description.blank? %>
-        <div class="container" >
-          <h3>Description</h3>
-          <div class="container" >
-            <%= @anthology.description %>
-          </div>
-        </div>
-      <% else %>
-        <div class="container" ><i> There is no description for this anthology.</i></div>
-      <% end %>
-      <div class="media-left" >
-        <% unless @anthology.banner.blank? %>
-          <div class="container" >
-            <%= link_to image_tag(@anthology.banner.url(:medium), class: 'media-object', style: "padding-top:15px;"), @anthology.banner.url(:medium), target: '_blank'  %>
-          </div>
-        <% end %>
-      </div>
-      <div class="container">
-        <div class="row">
-          <%= form_tag(anthology_path(id: @anthology.friendly_id, docs: "search_results"), :method => "get", class: 'navbar-form navbar-left') do %>
-            <div class="input-group form-group">
-              <%= search_field_tag :title, params[:title], placeholder: "Title", class: "form-control" %>
-              <div class="input-group-btn">
-                <%= button_tag "Search", :class => 'btn btn-info',:name => nil%>
-              </div>
-            </div>
-          <% end %>
-          <%= form_tag(anthology_path(id: @anthology.friendly_id, docs: "search_results"), :method => "get", class: 'navbar-form navbar-left') do %>
-            <div class="input-group">
-              <%= search_field_tag :author, params[:author], placeholder: "Author", class: "form-control" %>
-              <div class="input-group-btn">
-                <%= button_tag "Search", :class => 'btn btn-info',:name => nil%>
-              </div>
-            </div>
-          <% end %>
-          <%= form_tag(anthology_path(id: @anthology.friendly_id, docs: "search_results"), :method => "get", class: 'navbar-form navbar-left') do %>
-            <div class="input-group">
-              <%= search_field_tag :edition, params[:edition], placeholder: "Edition", class: "form-control" %>
-              <div class="input-group-btn">
-                <%= button_tag "Search", :class => 'btn btn-info',:name => nil%>
-              </div>
-            </div>
-          <% end %>
-        </div>
-      </div>
-      <div class="row">
-        <div class="col-md-12">
-          <div class="panel panel-default" id="dashboard-documents">
+    <div class="col-md-12">
+        <div class="panel panel-default" id="document-form">
             <div class="panel-heading">
-              <span class="panel-title">Documents</span>
-              <ul class="nav nav-tabs nav-tabs-xs pull-right" id="document-tabs" role="tablist">
-                <li class="<%= @tab_state['search_results'] %>">
-                  <%= link_to anthology_path( docs: 'search_results', title: params[:title],author: params[:author], edition: params[:edition], id: @anthology.friendly_id ), params do %>
-                    <span class='badge'><%= @search_documents_count %></span> Search Results
-                  <% end %>
-                </li>
-                <% if can? :manage, Document %>
-                  <li class="<%= @tab_state['all'] %>">
-                    <%= link_to anthology_path( docs: 'all', title: params[:title],author: params[:author], edition: params[:edition], id: @anthology.friendly_id ), params do %>
-                      <span class='badge'><%= @all_documents_count %></span> All
-                    <% end %>
-                  </li>
-                <% end %>
-              </ul>
+                <span class="panel-title">Anthology: <%= @anthology.name %></span>
             </div>
-            <div class="tab-content">
-              <div class="tab-pane no-padding active" id="all">
-                <% unless @documents.blank? %>
-                  <%= form_tag(anthology_add_path(anthology: @anthology.id), :method => "post") do %>
-                    <%= render partial: 'documents/document_table', locals: { documents: @documents } %>
-
-                    <% if current_user.admin? || current_user.teacher? %>
-                      <%= button_tag "Add selected to anthology", :class => 'btn btn-primary create-new-button',:name => nil%>
-                    <% end %>
-              <% end %>
-                <% else %>
-                  <div class="container">
-                    <tr>
-                      <td colspan="6">No documents to view.</td>
-                    </tr>
-                  </div>
-                <% end %>
-              </div>
-            </div>
-            <div class="panel-footer doc-set-footer">
-              <% if @documents.present? && @documents.count > 0 %>
-                <div class='pagination-controls'>
-                  <%= will_paginate @documents, renderer: BootstrapPagination::Rails %>
+            <% unless @anthology.description.blank? %>
+                <div class="container anthology-description">
+                    <h3>Description</h3>
+                    <div class="container">
+                        <%= @anthology.description %>
+                    </div>
                 </div>
-              <% end %>
+            <% else %>
+                <div class="container" ><i> There is no description for this anthology.</i></div>
+            <% end %>
+            <div class="media-left" >
+                <% unless @anthology.banner.blank? %>
+                    <div class="container" >
+                        <%= link_to image_tag(@anthology.banner.url(:medium), class: 'media-object', style: "padding-top:15px;"), @anthology.banner.url(:medium), target: '_blank'  %>
+                    </div>
+                <% end %>
             </div>
-          </div><!--/panel -->
-        </div><!--/col-md-12 -->
-      </div>
-    </div>
-  </div><!--/panel-body -->
+            <% if can? :manage, User %>
+              <div class="container">
+                <div class="media-left">
+                  <ul class="nav nav-tabs">
+                    <li role="presentation" class=<%= (params[:tab] == "documents" || params[:tab].nil?) ? 'active' : '' %>>
+                      <a href="?tab=documents">Documents</a>
+                    </li>
+                    <li role="presentation" class=<%= params[:tab] == "users" ? 'active' : '' %> >
+                      <a href="?tab=users">Users</a>
+                    </li>
+                  </ul>
+                </div>
+              </div>
+              <% if params[:tab] == "users" %>
+                <%= render 'users_tab', anthology: @anthology %>
+                <%= render 'searched_users', users: @users, anthology: @anthology, tab_state: @tab_state, search_users_count: @search_users_count, all_users_count: @all_users_count %>
+              <% else %>
+                <%= render 'documents_tab', anthology: @anthology %>
+                <%= render 'searched_documents', 
+                    search_documents_count: @search_documents_count, 
+                    tab_state: @tab_state,
+                    all_documents_count: @all_documents_count, 
+                    documents: @documents,
+                    anthology: @anthology 
+                  %>
+              <% end %>
+            <% else %> 
+              <%= render 'documents_tab', anthology: @anthology %>
+              <%= render 'searched_documents', 
+                search_documents_count: @search_documents_count, 
+                tab_state: @tab_state,
+                all_documents_count: @all_documents_count, 
+                documents: @documents,
+                anthology: @anthology 
+              %>
+            <% end %>
+
+            
+
+            
+
+            
+        </div>
+    </div><!--/panel-body -->
 </div><!--/panel -->

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,8 @@ AnnotationStudio::Application.routes.draw do
   post 'user_anthology_add', to: 'users#anthology_add'
   post 'remove_user', to: 'users#remove_user'
   post 'remove_doc', to: 'anthologies#remove_doc'
+  post 'remove_anthology_user', to: 'anthologies#remove_user'
+  post 'add_anthology_user', to: "anthologies#add_user"
 
   resources :documents do
     resources :annotations


### PR DESCRIPTION
## What this PR will accomplish
1. Admins will be able to search for users in the anthology show view and able to add them or remove them from anthologies 

# How to test
1. Login to http://cove-staging.herokuapp.com/ (user your admin account)
2. On dashboard page click on the Anthologies page at http://cove-staging.herokuapp.com/anthologies
3. Now click on any anthology from list for detail view
4. Click on the users tab
5. Try to search for a full name (You can use fuzzy search here and on the next PR case insensitive searches will be enabled as well)
6. After you find a user assign them to an anthology and click on the all tab to verify they are on the all list
7. Try to remove them from the anthology and make sure they are no longer on the all tab
8. Make sure you are not able to add or remove anyone from an anthology if you do use your normal nonadmin account.