### PR TITLE
Expand document and user search

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -171,3 +171,13 @@ img#neh-logo {
     color: #fff;
   }
 }
+
+.anthology-description { 
+  margin-bottom: 15px;
+}
+
+.an-searched-users-table-header { 
+  margin-bottom: 20px;
+  font-size: 16px;
+  color: inherit;
+}

--- a/app/controllers/anthologies_controller.rb
+++ b/app/controllers/anthologies_controller.rb
@@ -33,12 +33,12 @@ class AnthologiesController < ApplicationController
           [:email, :name].each do |query|
             if params.has_key?(query) && params[query].present?
               if query == :email
-                @search_users_count = User.where("users.email like ?", "%#{params[query]}%").count
-                @users = User.where("users.email like ?", "%#{params[query]}%")
+                @search_users_count = User.where("users.email ILIKE ?", "%#{params[query]}%").count
+                @users = User.where("users.email ILIKE ?", "%#{params[query]}%")
               elsif query == :name
-                @search_users_count = User.where("users.firstname like ? OR users.lastname like ? OR users.full_name like ?",
+                @search_users_count = User.where("users.firstname ILIKE ? OR users.lastname ILIKE ? OR users.full_name ILIKE ?",
                   "%#{params[query]}%", "%#{params[query]}%", "%#{params[query]}%").count
-                @users = User.where("users.firstname like ? OR users.lastname like ? OR users.full_name like ?",
+                @users = User.where("users.firstname ILIKE ? OR users.lastname ILIKE ? OR users.full_name ILIKE ?",
                   "%#{params[query]}%", "%#{params[query]}%", "%#{params[query]}%")
               end
             end
@@ -66,11 +66,12 @@ class AnthologiesController < ApplicationController
           [:title, :author, :edition].each do |query|
             if params.has_key?(query) && params[query].present?
               if query == :edition
-                @search_documents_count = Document.tagged_with(params[query]).count
-                @documents = Document.tagged_with(params[query])
+                tags = Tag.where('name ILIKE ?', "%#{params[query]}%").pluck(:name)
+                @search_documents_count = Document.tagged_with(tags, any: true).count
+                @documents = Document.tagged_with(tags, any: true)
               elsif params.has_key?(query) && params[query].present?
-                @search_documents_count = Document.where("#{query} LIKE ?", "%#{params[query]}%").count
-                @documents = Document.where("#{query} LIKE ?", "%#{params[query]}%")
+                @search_documents_count = Document.where("#{query} ILIKE ?", "%#{params[query]}%").count
+                @documents = Document.where("#{query} ILIKE ?", "%#{params[query]}%")
               end
             end
           end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -32,7 +32,7 @@ class Ability
       can :read, Document do |tors|
         !(user.rep_group_list & tors.rep_group_list).empty?
       end
-
+      cannot :manage, User
     else
       cannot :manage, :all
       can :read, Document, { :public? => true }

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,2 @@
+class Tag < ActiveRecord::Base
+end

--- a/app/views/anthologies/_documents_tab.html.erb
+++ b/app/views/anthologies/_documents_tab.html.erb
@@ -1,0 +1,28 @@
+<div class="container tab-pane" id="documents-001">
+    <div class="row">
+        <%= form_tag(anthology_path(id: anthology.friendly_id, docs: "search_results"), :method => "get", class: 'navbar-form navbar-left') do %>
+            <div class="input-group form-group">
+              <%= search_field_tag :title, params[:title], placeholder: "Title", class: "form-control" %>
+              <div class="input-group-btn">
+                <%= button_tag "Search", :class => 'btn btn-info',:name => nil %>
+              </div>
+            </div>
+          <% end %>
+          <%= form_tag(anthology_path(id: anthology.friendly_id, docs: "search_results"), :method => "get", class: 'navbar-form navbar-left') do %>
+            <div class="input-group">
+              <%= search_field_tag :author, params[:author], placeholder: "Author", class: "form-control" %>
+              <div class="input-group-btn">
+                <%= button_tag "Search", :class => 'btn btn-info',:name => nil %>
+              </div>
+            </div>
+          <% end %>
+          <%= form_tag(anthology_path(id: anthology.friendly_id, docs: "search_results"), :method => "get", class: 'navbar-form navbar-left') do %>
+            <div class="input-group">
+              <%= search_field_tag :edition, params[:edition], placeholder: "Edition", class: "form-control" %>
+              <div class="input-group-btn">
+                <%= button_tag "Search", :class => 'btn btn-info',:name => nil %>
+              </div>
+            </div>
+          <% end %>
+        </div>
+      </div>

--- a/app/views/anthologies/_searched_documents.erb
+++ b/app/views/anthologies/_searched_documents.erb
@@ -1,0 +1,51 @@
+<div class="container">
+<div class="row">
+<div class="col-md-12">
+  <div class="panel panel-default" id="dashboard-documents">
+    <div class="panel-heading">
+      <span class="panel-title">Documents</span>
+      <ul class="nav nav-tabs nav-tabs-xs pull-right" id="document-tabs" role="tablist">
+        <li class="<%= tab_state['search_results'] %>">
+          <%= link_to anthology_path( docs: 'search_results', title: params[:title],author: params[:author], edition: params[:edition], id: anthology.friendly_id, tab: params[:tab] ), params do %>
+            <span class='badge'><%= search_documents_count %></span> Search Results
+          <% end %>
+        </li>
+        <% if can? :manage, Document %>
+          <li class="<%= tab_state['all'] %>">
+            <%= link_to anthology_path( docs: 'all', title: params[:title],author: params[:author], edition: params[:edition], id: anthology.friendly_id, tab: params[:tab] ), params do %>
+              <span class='badge'><%= all_documents_count %></span> All
+            <% end %>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+    <div class="tab-content">
+      <div class="tab-pane no-padding active" id="all">
+        <% unless documents.blank? %>
+          <%= form_tag(anthology_add_path(anthology: anthology.id), :method => "post") do %>
+            <%= render partial: 'documents/document_table', locals: { documents: documents } %>
+
+            <% if current_user.admin? || current_user.teacher? %>
+              <%= button_tag "Add selected to anthology", :class => 'btn btn-primary create-new-button',:name => nil%>
+            <% end %>
+      <% end %>
+        <% else %>
+          <div class="container">
+            <tr>
+              <td colspan="6">No documents to view.</td>
+            </tr>
+          </div>
+        <% end %>
+      </div>
+    </div>
+    <div class="panel-footer doc-set-footer">
+      <% if documents.present? && documents.count > 0 %>
+        <div class='pagination-controls'>
+          <%= will_paginate documents, renderer: BootstrapPagination::Rails %>
+        </div>
+      <% end %>
+    </div>
+  </div><!--/panel -->
+</div><!--/col-md-12 -->
+</div>
+</div>

--- a/app/views/anthologies/_searched_documents.erb
+++ b/app/views/anthologies/_searched_documents.erb
@@ -24,11 +24,7 @@
         <% unless documents.blank? %>
           <%= form_tag(anthology_add_path(anthology: anthology.id), :method => "post") do %>
             <%= render partial: 'documents/document_table', locals: { documents: documents } %>
-
-            <% if current_user.admin? || current_user.teacher? %>
-              <%= button_tag "Add selected to anthology", :class => 'btn btn-primary create-new-button',:name => nil%>
-            <% end %>
-      <% end %>
+        <% end %>
         <% else %>
           <div class="container">
             <tr>

--- a/app/views/anthologies/_searched_users.html.erb
+++ b/app/views/anthologies/_searched_users.html.erb
@@ -1,0 +1,47 @@
+<div class="container">
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <span class="an-searched-users-table-header">Users</span>
+                <ul class="nav nav-tabs nav-tabs-xs pull-right" id="document-tabs" role="tablist">
+                    <li class="<%= tab_state['search_results'] %>">
+                        <%= link_to anthology_path( docs: 'search_results', name: params[:name],email: params[:email], tab: params[:tab], id: anthology.friendly_id ), params do %>
+                            <span class='badge'><%= search_users_count %></span> Search Results
+                        <% end %>
+                    </li>
+                    <li class="<%= tab_state['all'] %>">
+                        <%= link_to anthology_path( docs: 'all', name: params[:name],email: params[:email], tab: params[:tab], id: anthology.friendly_id ), params do %>
+                            <span class='badge'><%= all_users_count %></span> All
+                        <% end %>
+                    </li>
+                </ul>
+            <% if users.count.zero? %>
+                <i> No users are assigned to this anthology </i>
+            <% else %>
+                <table class="table table-striped table-bordered">
+                    <thead>
+                        <tr>
+                            <th>Full Name</th>
+                            <th>Email</th>
+                            <th>Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <% users.each do |user| %>
+                            <tr>
+                                <td> <%= link_to "#{user.firstname} #{user.lastname}", user_path(user.id) %> </td>
+                                <td> <%= user.email %> </td>
+                                <td>
+                                    <% if anthology.users.include?(user) %>
+                                        <%= link_to 'Remove From Anthology', { action: :remove_user, controller: 'anthologies', anthology_id: anthology.id, user_id: user.id}, method: :post , :class => 'btn btn-danger btn-md' %>
+                                    <% else  %>
+                                        <%= link_to 'Assign To Anthology', { action: :add_user, controller: 'anthologies', anthology_id: anthology.id, user_id: user.id}, method: :post, :class => 'btn btn-primary btn-md' %>
+                                    <% end %>
+                                </td>
+                            </tr>
+                        <% end %>
+                    </tbody>
+                </table>
+            <% end %>
+        </div>
+    </div>
+</div>

--- a/app/views/anthologies/_users_tab.html.erb
+++ b/app/views/anthologies/_users_tab.html.erb
@@ -1,23 +1,23 @@
 <div class="container tab-pane" id="users-001">
-        <div class="row">
-          <%= form_tag(anthology_path(id: anthology.friendly_id, docs: "search_results"), :method => "get", class: 'navbar-form navbar-left') do %>
-            <div class="input-group form-group">
-              <%= search_field_tag :email, params[:email], placeholder: "Email", class: "form-control" %>
-              <%= hidden_field_tag :tab , "users" %>
-              <div class="input-group-btn">
-                <%= button_tag "Search", :class => 'btn btn-info',:name => nil %>
-              </div>
-            </div>
-          <% end %>
-
-          <%= form_tag(anthology_path(id: anthology.friendly_id, docs: "search_results"), :method => "get", class: 'navbar-form navbar-left') do %>
-            <div class="input-group">
-              <%= search_field_tag :name, params[:name], placeholder: "Full Name", class: "form-control" %>
-              <%= hidden_field_tag :tab , "users" %>
-              <div class="input-group-btn">
-                <%= button_tag "Search", :class => 'btn btn-info',:name => nil %>
-              </div>
-            </div>
-          <% end %>
+  <div class="row">
+    <%= form_tag(anthology_path(id: anthology.friendly_id, docs: "search_results"), :method => "get", class: 'navbar-form navbar-left') do %>
+    <div class="input-group form-group">
+        <%= search_field_tag :email, params[:email], placeholder: "Email", class: "form-control" %>
+        <%= hidden_field_tag :tab , "users" %>
+        <div class="input-group-btn">
+        <%= button_tag "Search", :class => 'btn btn-info',:name => nil %>
         </div>
-      </div>
+    </div>
+    <% end %>
+
+    <%= form_tag(anthology_path(id: anthology.friendly_id, docs: "search_results"), :method => "get", class: 'navbar-form navbar-left') do %>
+    <div class="input-group">
+        <%= search_field_tag :name, params[:name], placeholder: "Full Name", class: "form-control" %>
+        <%= hidden_field_tag :tab , "users" %>
+        <div class="input-group-btn">
+        <%= button_tag "Search", :class => 'btn btn-info',:name => nil %>
+        </div>
+    </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/anthologies/_users_tab.html.erb
+++ b/app/views/anthologies/_users_tab.html.erb
@@ -1,0 +1,23 @@
+<div class="container tab-pane" id="users-001">
+        <div class="row">
+          <%= form_tag(anthology_path(id: anthology.friendly_id, docs: "search_results"), :method => "get", class: 'navbar-form navbar-left') do %>
+            <div class="input-group form-group">
+              <%= search_field_tag :email, params[:email], placeholder: "Email", class: "form-control" %>
+              <%= hidden_field_tag :tab , "users" %>
+              <div class="input-group-btn">
+                <%= button_tag "Search", :class => 'btn btn-info',:name => nil %>
+              </div>
+            </div>
+          <% end %>
+
+          <%= form_tag(anthology_path(id: anthology.friendly_id, docs: "search_results"), :method => "get", class: 'navbar-form navbar-left') do %>
+            <div class="input-group">
+              <%= search_field_tag :name, params[:name], placeholder: "Full Name", class: "form-control" %>
+              <%= hidden_field_tag :tab , "users" %>
+              <div class="input-group-btn">
+                <%= button_tag "Search", :class => 'btn btn-info',:name => nil %>
+              </div>
+            </div>
+          <% end %>
+        </div>
+      </div>

--- a/app/views/anthologies/show.html.erb
+++ b/app/views/anthologies/show.html.erb
@@ -1,104 +1,69 @@
 <%= content_for :body_id, 'documents' %>
 <div class="row">
-  <div class="col-md-12">
-    <div class="panel panel-default" id="document-form">
-      <div class="panel-heading">
-        <span class="panel-title">Anthology: <%= @anthology.name %></span>
-      </div>
-      <% unless @anthology.description.blank? %>
-        <div class="container" >
-          <h3>Description</h3>
-          <div class="container" >
-            <%= @anthology.description %>
-          </div>
-        </div>
-      <% else %>
-        <div class="container" ><i> There is no description for this anthology.</i></div>
-      <% end %>
-      <div class="media-left" >
-        <% unless @anthology.banner.blank? %>
-          <div class="container" >
-            <%= link_to image_tag(@anthology.banner.url(:medium), class: 'media-object', style: "padding-top:15px;"), @anthology.banner.url(:medium), target: '_blank'  %>
-          </div>
-        <% end %>
-      </div>
-      <div class="container">
-        <div class="row">
-          <%= form_tag(anthology_path(id: @anthology.friendly_id, docs: "search_results"), :method => "get", class: 'navbar-form navbar-left') do %>
-            <div class="input-group form-group">
-              <%= search_field_tag :title, params[:title], placeholder: "Title", class: "form-control" %>
-              <div class="input-group-btn">
-                <%= button_tag "Search", :class => 'btn btn-info',:name => nil%>
-              </div>
-            </div>
-          <% end %>
-          <%= form_tag(anthology_path(id: @anthology.friendly_id, docs: "search_results"), :method => "get", class: 'navbar-form navbar-left') do %>
-            <div class="input-group">
-              <%= search_field_tag :author, params[:author], placeholder: "Author", class: "form-control" %>
-              <div class="input-group-btn">
-                <%= button_tag "Search", :class => 'btn btn-info',:name => nil%>
-              </div>
-            </div>
-          <% end %>
-          <%= form_tag(anthology_path(id: @anthology.friendly_id, docs: "search_results"), :method => "get", class: 'navbar-form navbar-left') do %>
-            <div class="input-group">
-              <%= search_field_tag :edition, params[:edition], placeholder: "Edition", class: "form-control" %>
-              <div class="input-group-btn">
-                <%= button_tag "Search", :class => 'btn btn-info',:name => nil%>
-              </div>
-            </div>
-          <% end %>
-        </div>
-      </div>
-      <div class="row">
-        <div class="col-md-12">
-          <div class="panel panel-default" id="dashboard-documents">
+    <div class="col-md-12">
+        <div class="panel panel-default" id="document-form">
             <div class="panel-heading">
-              <span class="panel-title">Documents</span>
-              <ul class="nav nav-tabs nav-tabs-xs pull-right" id="document-tabs" role="tablist">
-                <li class="<%= @tab_state['search_results'] %>">
-                  <%= link_to anthology_path( docs: 'search_results', title: params[:title],author: params[:author], edition: params[:edition], id: @anthology.friendly_id ), params do %>
-                    <span class='badge'><%= @search_documents_count %></span> Search Results
-                  <% end %>
-                </li>
-                <% if can? :manage, Document %>
-                  <li class="<%= @tab_state['all'] %>">
-                    <%= link_to anthology_path( docs: 'all', title: params[:title],author: params[:author], edition: params[:edition], id: @anthology.friendly_id ), params do %>
-                      <span class='badge'><%= @all_documents_count %></span> All
-                    <% end %>
-                  </li>
-                <% end %>
-              </ul>
+                <span class="panel-title">Anthology: <%= @anthology.name %></span>
             </div>
-            <div class="tab-content">
-              <div class="tab-pane no-padding active" id="all">
-                <% unless @documents.blank? %>
-                  <%= form_tag(anthology_add_path(anthology: @anthology.id), :method => "post") do %>
-                    <%= render partial: 'documents/document_table', locals: { documents: @documents } %>
-
-                    <% if current_user.admin? || current_user.teacher? %>
-                      <%= button_tag "Add selected to anthology", :class => 'btn btn-primary create-new-button',:name => nil%>
-                    <% end %>
-              <% end %>
-                <% else %>
-                  <div class="container">
-                    <tr>
-                      <td colspan="6">No documents to view.</td>
-                    </tr>
-                  </div>
-                <% end %>
-              </div>
-            </div>
-            <div class="panel-footer doc-set-footer">
-              <% if @documents.present? && @documents.count > 0 %>
-                <div class='pagination-controls'>
-                  <%= will_paginate @documents, renderer: BootstrapPagination::Rails %>
+            <% unless @anthology.description.blank? %>
+                <div class="container anthology-description">
+                    <h3>Description</h3>
+                    <div class="container">
+                        <%= @anthology.description %>
+                    </div>
                 </div>
-              <% end %>
+            <% else %>
+                <div class="container" ><i> There is no description for this anthology.</i></div>
+            <% end %>
+            <div class="media-left" >
+                <% unless @anthology.banner.blank? %>
+                    <div class="container" >
+                        <%= link_to image_tag(@anthology.banner.url(:medium), class: 'media-object', style: "padding-top:15px;"), @anthology.banner.url(:medium), target: '_blank'  %>
+                    </div>
+                <% end %>
             </div>
-          </div><!--/panel -->
-        </div><!--/col-md-12 -->
-      </div>
-    </div>
-  </div><!--/panel-body -->
+            <% if can? :manage, User %>
+              <div class="container">
+                <div class="media-left">
+                  <ul class="nav nav-tabs">
+                    <li role="presentation" class=<%= (params[:tab] == "documents" || params[:tab].nil?) ? 'active' : '' %>>
+                      <a href="?tab=documents">Documents</a>
+                    </li>
+                    <li role="presentation" class=<%= params[:tab] == "users" ? 'active' : '' %> >
+                      <a href="?tab=users">Users</a>
+                    </li>
+                  </ul>
+                </div>
+              </div>
+              <% if params[:tab] == "users" %>
+                <%= render 'users_tab', anthology: @anthology %>
+                <%= render 'searched_users', users: @users, anthology: @anthology, tab_state: @tab_state, search_users_count: @search_users_count, all_users_count: @all_users_count %>
+              <% else %>
+                <%= render 'documents_tab', anthology: @anthology %>
+                <%= render 'searched_documents', 
+                    search_documents_count: @search_documents_count, 
+                    tab_state: @tab_state,
+                    all_documents_count: @all_documents_count, 
+                    documents: @documents,
+                    anthology: @anthology 
+                  %>
+              <% end %>
+            <% else %> 
+              <%= render 'documents_tab', anthology: @anthology %>
+              <%= render 'searched_documents', 
+                search_documents_count: @search_documents_count, 
+                tab_state: @tab_state,
+                all_documents_count: @all_documents_count, 
+                documents: @documents,
+                anthology: @anthology 
+              %>
+            <% end %>
+
+            
+
+            
+
+            
+        </div>
+    </div><!--/panel-body -->
 </div><!--/panel -->

--- a/app/views/documents/_document_table.html.erb
+++ b/app/views/documents/_document_table.html.erb
@@ -1,43 +1,38 @@
 <table class="table table-striped table-bordered">
   <tr>
-    <% if current_user.admin? || current_user.teacher? %>
-      <th></th>
-    <% end %>
-      <th><%= link_to "Title", documents_path( order: "title", docs: params[:docs], title: params[:title],author: params[:author], edition: params[:edition], anthology_id: params[:anthology_id] ) %>
-      </th>
-      <th><%= link_to "Author", documents_path( order: "author", docs: params[:docs], title: params[:title],author: params[:author], edition: params[:edition], anthology_id: params[:anthology_id] ) %>
-      </th>
-      <th><%= link_to "Created", documents_path( order: "created_at", docs: params[:docs], title: params[:title],author: params[:author], edition: params[:edition], anthology_id: params[:anthology_id] ) %>    </th>
+    <th>
+        <%= link_to "Title", documents_path( order: "title", docs: params[:docs], title: params[:title],author: params[:author], edition: params[:edition], anthology_id: params[:anthology_id] ) %>
+    </th>
+    <th>
+        <%= link_to "Author", documents_path( order: "author", docs: params[:docs], title: params[:title],author: params[:author], edition: params[:edition], anthology_id: params[:anthology_id] ) %>
+    </th>
+    <th>
+      <%= link_to "Created", documents_path( order: "created_at", docs: params[:docs], title: params[:title],author: params[:author], edition: params[:edition], anthology_id: params[:anthology_id] ) %>
+    </th>
     <th><%= ENV["CLASS_TERM_PLURAL"] %></th>
     <th>Status</th>
     <th>Actions</th>
   </tr>
   <% documents.each do |document| %>
     <tr>
-      <% if current_user.admin? || current_user.teacher? %>
-        <% if document.anthologies.include?(@anthology) %>
-          <td><div class="<%= "document_of_#{document.id}" %>" ><%= check_box_tag 'document_ids[]', document.id,  :checked => "checked" %></div></td>
-        <% else %>
-          <td><div class="<%= "document_of_#{document.id}"%>" ><%= check_box_tag 'document_ids[]',  document.id %></div></td>
-        <% end %>
-      <% end %>
       <td>
         <% if controller_name == 'anthologies' %>
           <%= link_to document.title, anthology_document_path(@anthology.friendly_id, document.friendly_id) %></td>
-    <% else %>
-      <%= link_to document.title, document_path(document.friendly_id) %></td>
-  <% end %>
-  <td>
-    <%= document.author %></td>
-  <td>
-    <%= document.created_at.strftime("%m/%d/%Y") %></td>
-  <td>
-    <% document.rep_group_list.each do |group| %>
-      <span class="label label-info">
-        <%= group %></span>
-    <% end %></td>
-  <td>
-    <% if can? :update, document %>
+        <% else %>
+          <%= link_to document.title, document_path(document.friendly_id) %>
+        <% end %>
+      </td>
+      <td>
+        <%= document.author %></td>
+      <td>
+        <%= document.created_at.strftime("%m/%d/%Y") %></td>
+      <td>
+        <% document.rep_group_list.each do |group| %>
+          <span class="label label-info">
+            <%= group %></span>
+        <% end %></td>
+      <td>
+      <% if can? :update, document %>
       <div class="btn-group" role="group" aria-label="document states">
 
         <% if document.draft? %>
@@ -94,7 +89,11 @@
         <% end %>
       <% end %>
       <% if document.anthologies.include?(@anthology) && current_user.admin? %>
-        <%= link_to 'Remove from anthology', { action: :remove_doc, controller: 'anthologies', anthology_id: @anthology.id, document_id: document.id }, method: :post, :class => 'btn btn-danger btn-sm' %>
+        <%= link_to 'Remove from anthology',
+            { action: :remove_doc, controller: 'anthologies', anthology_id: @anthology.id, document_id: document.id }, method: :post, :class => 'btn btn-danger btn-sm' %>
+      <% else %>
+        <%= link_to 'Assign to Anthology',
+          { action: :anthology_add, controller: 'documents', anthology: @anthology.id, document_ids: [document.id]}, method: :post, :class => 'btn btn-primary btn-sm' %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/users/_user_table.html.erb
+++ b/app/views/users/_user_table.html.erb
@@ -21,7 +21,8 @@
         <%= user.email %></td>
       <td class="button-column">
         <% if @anthology.present? &&  user.anthologies.include?(@anthology) && @anthologies.include?(@anthology) %>
-          <%= link_to 'Remove from anthology', { action: :remove_user, controller: 'users', anthology_id: @anthology.id, user_id: user.id}, method: :post, :class => 'btn btn-danger btn-sm' %>
+          <%= link_to 'Remove from anthology',
+            { action: :remove_user, controller: 'users', anthology_id: @anthology.id, user_id: user.id}, method: :post, :class => 'btn btn-danger btn-sm' %>
         <% end %>
       <% end %>
 </table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,8 @@ AnnotationStudio::Application.routes.draw do
   post 'user_anthology_add', to: 'users#anthology_add'
   post 'remove_user', to: 'users#remove_user'
   post 'remove_doc', to: 'anthologies#remove_doc'
+  post 'remove_anthology_user', to: 'anthologies#remove_user'
+  post 'add_anthology_user', to: "anthologies#add_user"
 
   resources :documents do
     resources :annotations


### PR DESCRIPTION
## What does this PR do?
1. Allows admins to search for users by name and email using fuzzy search (eg. Tim could be found by Ti) and case insensitive search
2. Allow users to search for documents by edition, title or name using fuzzy search and case insensitive search
## How to test?
1. Go to http://cove-staging.herokuapp.com/anthologies and click on any anthology
2. Click on the users tab and search any name both lowercase and uppercase 
3. Search for users by using fuzzy search (eg. Tim could be found by Ti) 
4. Click on the documents tab and search documents by uppercase and lowercase
5. Search for documents by fuzzy search (eg. United or Uni)