### PR TITLE
Fix pagination on anthology show and anthology group functionality

### DIFF
--- a/app/assets/stylesheets/anthologies.scss
+++ b/app/assets/stylesheets/anthologies.scss
@@ -1,3 +1,21 @@
 // Place all the styles related to the anthologies controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
+
+.anthology-description { 
+  margin-bottom: 15px;
+}
+
+.an-searched-users-table-header { 
+  margin-bottom: 20px;
+  font-size: 16px;
+  color: inherit;
+}
+
+.anthologies-list-title-action {
+  min-width: 25vh;
+}
+
+.search-tabs-wrapper {
+  margin-top: 20px;
+}

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -26,6 +26,7 @@
  *= require "catalog"
  *= require "ekko-lightbox.min"
  *= require "navbar-overrides.css"
+ *= require "anthologies"
  */
 
 html {
@@ -170,14 +171,4 @@ img#neh-logo {
     margin-top: 12px;
     color: #fff;
   }
-}
-
-.anthology-description { 
-  margin-bottom: 15px;
-}
-
-.an-searched-users-table-header { 
-  margin-bottom: 20px;
-  font-size: 16px;
-  color: inherit;
 }

--- a/app/controllers/anthologies_controller.rb
+++ b/app/controllers/anthologies_controller.rb
@@ -33,12 +33,12 @@ class AnthologiesController < ApplicationController
           [:email, :name].each do |query|
             if params.has_key?(query) && params[query].present?
               if query == :email
-                @search_users_count = User.where("users.email like ?", "%#{params[query]}%").count
-                @users = User.where("users.email like ?", "%#{params[query]}%")
+                @search_users_count = User.where("users.email ILIKE ?", "%#{params[query]}%").count
+                @users = User.where("users.email ILIKE ?", "%#{params[query]}%")
               elsif query == :name
-                @search_users_count = User.where("users.firstname like ? OR users.lastname like ? OR users.full_name like ?",
+                @search_users_count = User.where("users.firstname ILIKE ? OR users.lastname ILIKE ? OR users.full_name ILIKE ?",
                   "%#{params[query]}%", "%#{params[query]}%", "%#{params[query]}%").count
-                @users = User.where("users.firstname like ? OR users.lastname like ? OR users.full_name like ?",
+                @users = User.where("users.firstname ILIKE ? OR users.lastname ILIKE ? OR users.full_name ILIKE ?",
                   "%#{params[query]}%", "%#{params[query]}%", "%#{params[query]}%")
               end
             end
@@ -66,11 +66,12 @@ class AnthologiesController < ApplicationController
           [:title, :author, :edition].each do |query|
             if params.has_key?(query) && params[query].present?
               if query == :edition
-                @search_documents_count = Document.tagged_with(params[query]).count
-                @documents = Document.tagged_with(params[query])
+                tags = Tag.where('name ILIKE ?', "%#{params[query]}%").pluck(:name)
+                @search_documents_count = Document.tagged_with(tags, any: true).count
+                @documents = Document.tagged_with(tags, any: true)
               elsif params.has_key?(query) && params[query].present?
-                @search_documents_count = Document.where("#{query} LIKE ?", "%#{params[query]}%").count
-                @documents = Document.where("#{query} LIKE ?", "%#{params[query]}%")
+                @search_documents_count = Document.where("#{query} ILIKE ?", "%#{params[query]}%").count
+                @documents = Document.where("#{query} ILIKE ?", "%#{params[query]}%")
               end
             end
           end

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -20,6 +20,8 @@ class DocumentsController < ApplicationController
       Rails.logger.info "anthology is #{anthology.inspect}"
       params[:document_ids].each do |doc_id|
         doc = Document.find(doc_id)
+        doc.rep_group_list.add(anthology.slug)
+        doc.save
         unless anthology.documents.include?(doc)
           anthology.documents << doc
           documents << doc.title

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -189,7 +189,7 @@ class DocumentsController < ApplicationController
           Delayed::Job.enqueue DocumentProcessor.new(@document.id, @document.state, Apartment::Database.current_tenant)
           @document.pending!
         end
-        format.html { redirect_to documents_url, notice: 'Document was successfully created.', anchor: 'created'}
+        format.html { redirect_to documents_url(docs: 'created'), notice: 'Document was successfully created.', anchor: 'created'}
         format.json { render json: @document, status: :created, location: @document }
       else
         format.html { render action: "new" }

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,2 @@
+class Tag < ActiveRecord::Base
+end

--- a/app/views/anthologies/_searched_documents.erb
+++ b/app/views/anthologies/_searched_documents.erb
@@ -24,11 +24,7 @@
         <% unless documents.blank? %>
           <%= form_tag(anthology_add_path(anthology: anthology.id), :method => "post") do %>
             <%= render partial: 'documents/document_table', locals: { documents: documents } %>
-
-            <% if current_user.admin? || current_user.teacher? %>
-              <%= button_tag "Add selected to anthology", :class => 'btn btn-primary create-new-button',:name => nil%>
-            <% end %>
-      <% end %>
+        <% end %>
         <% else %>
           <div class="container">
             <tr>

--- a/app/views/anthologies/_searched_users.html.erb
+++ b/app/views/anthologies/_searched_users.html.erb
@@ -32,15 +32,16 @@
                                 <td> <%= user.email %> </td>
                                 <td>
                                     <% if anthology.users.include?(user) %>
-                                        <%= link_to 'Remove From Anthology', { action: :remove_user, controller: 'anthologies', anthology_id: anthology.id, user_id: user.id}, method: :post , :class => 'btn btn-danger btn-md' %>
+                                        <%= link_to 'Remove From Anthology', { action: :remove_user, controller: 'anthologies', anthology_id: anthology.id, user_id: user.id, name: @searched_name, email: @searched_email}, method: :post , :class => 'btn btn-danger btn-md' %>
                                     <% else  %>
-                                        <%= link_to 'Assign To Anthology', { action: :add_user, controller: 'anthologies', anthology_id: anthology.id, user_id: user.id}, method: :post, :class => 'btn btn-primary btn-md' %>
+                                        <%= link_to 'Assign To Anthology', { action: :add_user, controller: 'anthologies', anthology_id: anthology.id, user_id: user.id, name: @searched_name, email: @searched_email}, method: :post, :class => 'btn btn-primary btn-md' %>
                                     <% end %>
                                 </td>
                             </tr>
                         <% end %>
                     </tbody>
                 </table>
+            <%= will_paginate  @users, renderer: BootstrapPagination::Rails %>
             <% end %>
         </div>
     </div>

--- a/app/views/anthologies/_users_tab.html.erb
+++ b/app/views/anthologies/_users_tab.html.erb
@@ -1,23 +1,23 @@
 <div class="container tab-pane" id="users-001">
-        <div class="row">
-          <%= form_tag(anthology_path(id: anthology.friendly_id, docs: "search_results"), :method => "get", class: 'navbar-form navbar-left') do %>
-            <div class="input-group form-group">
-              <%= search_field_tag :email, params[:email], placeholder: "Email", class: "form-control" %>
-              <%= hidden_field_tag :tab , "users" %>
-              <div class="input-group-btn">
-                <%= button_tag "Search", :class => 'btn btn-info',:name => nil %>
-              </div>
-            </div>
-          <% end %>
-
-          <%= form_tag(anthology_path(id: anthology.friendly_id, docs: "search_results"), :method => "get", class: 'navbar-form navbar-left') do %>
-            <div class="input-group">
-              <%= search_field_tag :name, params[:name], placeholder: "Full Name", class: "form-control" %>
-              <%= hidden_field_tag :tab , "users" %>
-              <div class="input-group-btn">
-                <%= button_tag "Search", :class => 'btn btn-info',:name => nil %>
-              </div>
-            </div>
-          <% end %>
+  <div class="row">
+    <%= form_tag(anthology_path(id: anthology.friendly_id, docs: "search_results"), :method => "get", class: 'navbar-form navbar-left') do %>
+    <div class="input-group form-group">
+        <%= search_field_tag :email, params[:email], placeholder: "Email", class: "form-control" %>
+        <%= hidden_field_tag :tab , "users" %>
+        <div class="input-group-btn">
+        <%= button_tag "Search", :class => 'btn btn-info',:name => nil %>
         </div>
-      </div>
+    </div>
+    <% end %>
+
+    <%= form_tag(anthology_path(id: anthology.friendly_id, docs: "search_results"), :method => "get", class: 'navbar-form navbar-left') do %>
+    <div class="input-group">
+        <%= search_field_tag :name, params[:name], placeholder: "Full Name", class: "form-control" %>
+        <%= hidden_field_tag :tab , "users" %>
+        <div class="input-group-btn">
+        <%= button_tag "Search", :class => 'btn btn-info',:name => nil %>
+        </div>
+    </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/anthologies/edit.html.erb
+++ b/app/views/anthologies/edit.html.erb
@@ -1,9 +1,10 @@
 <%= content_for :body_id, 'documents' %>
+<%= content_for :page_title, @anthology.name %>
 <div class="row">
   <div class="col-md-12">
     <div class="panel panel-default" id="document-form">
       <div class="panel-heading">
-        <span class="panel-title">Edit Anthology</span>
+        <span class="panel-title">Edit Anthology(<%= @anthology.name %>)</span>
       </div>
       <% if @anthology.user == current_user %>
       <%= render partial: 'form' %>

--- a/app/views/anthologies/index.html.erb
+++ b/app/views/anthologies/index.html.erb
@@ -8,9 +8,9 @@
     </div>
     <table class="table table-striped table-bordered">
       <tr>
-        <th>Name</th>
+        <th class="anthologies-list-title-action">Name</th>
         <th>Description</th>
-        <th>Actions</th>
+        <th class="anthologies-list-title-action">Actions</th>
       </tr>
       <% if @anthologies.count >= 1 %>
         <% @anthologies.each do |anthology| %>

--- a/app/views/anthologies/show.html.erb
+++ b/app/views/anthologies/show.html.erb
@@ -1,3 +1,4 @@
+<%= content_for :page_title, @anthology.name %>
 <%= content_for :body_id, 'documents' %>
 <div class="row">
   <div class="col-md-12">

--- a/app/views/anthologies/show.html.erb
+++ b/app/views/anthologies/show.html.erb
@@ -1,69 +1,73 @@
 <%= content_for :body_id, 'documents' %>
 <div class="row">
-    <div class="col-md-12">
-        <div class="panel panel-default" id="document-form">
-            <div class="panel-heading">
-                <span class="panel-title">Anthology: <%= @anthology.name %></span>
-            </div>
-            <% unless @anthology.description.blank? %>
-                <div class="container anthology-description">
-                    <h3>Description</h3>
-                    <div class="container">
-                        <%= @anthology.description %>
-                    </div>
-                </div>
-            <% else %>
-                <div class="container" ><i> There is no description for this anthology.</i></div>
-            <% end %>
-            <div class="media-left" >
-                <% unless @anthology.banner.blank? %>
-                    <div class="container" >
-                        <%= link_to image_tag(@anthology.banner.url(:medium), class: 'media-object', style: "padding-top:15px;"), @anthology.banner.url(:medium), target: '_blank'  %>
-                    </div>
-                <% end %>
-            </div>
-            <% if can? :manage, User %>
-              <div class="container">
-                <div class="media-left">
-                  <ul class="nav nav-tabs">
-                    <li role="presentation" class=<%= (params[:tab] == "documents" || params[:tab].nil?) ? 'active' : '' %>>
-                      <a href="?tab=documents">Documents</a>
-                    </li>
-                    <li role="presentation" class=<%= params[:tab] == "users" ? 'active' : '' %> >
-                      <a href="?tab=users">Users</a>
-                    </li>
-                  </ul>
-                </div>
-              </div>
-              <% if params[:tab] == "users" %>
-                <%= render 'users_tab', anthology: @anthology %>
-                <%= render 'searched_users', users: @users, anthology: @anthology, tab_state: @tab_state, search_users_count: @search_users_count, all_users_count: @all_users_count %>
-              <% else %>
-                <%= render 'documents_tab', anthology: @anthology %>
-                <%= render 'searched_documents', 
-                    search_documents_count: @search_documents_count, 
-                    tab_state: @tab_state,
-                    all_documents_count: @all_documents_count, 
-                    documents: @documents,
-                    anthology: @anthology 
-                  %>
-              <% end %>
-            <% else %> 
-              <%= render 'documents_tab', anthology: @anthology %>
-              <%= render 'searched_documents', 
-                search_documents_count: @search_documents_count, 
-                tab_state: @tab_state,
-                all_documents_count: @all_documents_count, 
-                documents: @documents,
-                anthology: @anthology 
-              %>
-            <% end %>
-
-            
-
-            
-
-            
+  <div class="col-md-12">
+    <div class="panel panel-default" id="document-form">
+      <div class="panel-heading">
+        <span class="panel-title">Anthology: <%= @anthology.name %></span>
+      </div>
+      <% unless @anthology.description.blank? %>
+        <div class="container anthology-description">
+          <h3>Description</h3>
+          <div class="container">
+            <%= @anthology.description %>
+          </div>
         </div>
-    </div><!--/panel-body -->
+      <% else %>
+        <div class="container" ><i> There is no description for this anthology.</i></div>
+      <% end %>
+      <div class="media-left" >
+        <% unless @anthology.banner.blank? %>
+          <div class="container" >
+            <%= link_to image_tag(@anthology.banner.url(:medium), class: 'media-object', style: "padding-top:15px;"), @anthology.banner.url(:medium), target: '_blank'  %>
+          </div>
+        <% end %>
+      </div>
+      <div class="search-tabs-wrapper">
+        <% if can? :manage, User %>
+          <div class="container">
+            <div class="media-left">
+              <ul class="nav nav-tabs">
+                <li role="presentation" class=<%= (params[:tab] == "documents" || params[:tab].nil?) ? 'active' : '' %>>
+                  <a href="?tab=documents">Documents</a>
+                </li>
+                <li role="presentation" class=<%= params[:tab] == "users" ? 'active' : '' %> >
+                  <a href="?tab=users">Users</a>
+                </li>
+              </ul>
+            </div>
+          </div>
+          <% if params[:tab] == "users" %>
+
+            <%= render 'users_tab', anthology: @anthology %>
+            <%= render 'searched_users', users: @users, anthology: @anthology, tab_state: @tab_state, search_users_count: @search_users_count, all_users_count: @all_users_count %>
+
+          <% else %>
+            <%= render 'documents_tab', anthology: @anthology %>
+            <%= render 'searched_documents',
+                       search_documents_count: @search_documents_count,
+                       tab_state: @tab_state,
+                       all_documents_count: @all_documents_count,
+                       documents: @documents,
+                       anthology: @anthology
+            %>
+          <% end %>
+        <% else %>
+          <%= render 'documents_tab', anthology: @anthology %>
+          <%= render 'searched_documents',
+                     search_documents_count: @search_documents_count,
+                     tab_state: @tab_state,
+                     all_documents_count: @all_documents_count,
+                     documents: @documents,
+                     anthology: @anthology
+          %>
+        <% end %>
+      </div>
+
+
+
+
+
+
+    </div>
+  </div><!--/panel-body -->
 </div><!--/panel -->

--- a/app/views/documents/_document_table.html.erb
+++ b/app/views/documents/_document_table.html.erb
@@ -88,7 +88,7 @@
           <%= link_to 'Edit', edit_document_path(document), :class => 'btn btn-default btn-sm', data: { toggle: 'tooltip', placement: 'top', original_title: 'Only metadata are editable' } %>
         <% end %>
       <% end %>
-      <% if controller_name == 'Anthologies' %>
+      <% if controller_name == 'anthologies' && current_user.admin? %>
         <% if document.anthologies.include?(@anthology) && current_user.admin? %>
           <%= link_to 'Remove from anthology',
               { action: :remove_doc, controller: 'anthologies', anthology_id: @anthology.id, document_id: document.id }, method: :post, :class => 'btn btn-danger btn-sm' %>

--- a/app/views/documents/_document_table.html.erb
+++ b/app/views/documents/_document_table.html.erb
@@ -1,43 +1,38 @@
 <table class="table table-striped table-bordered">
   <tr>
-    <% if current_user.admin? || current_user.teacher? %>
-      <th></th>
-    <% end %>
-      <th><%= link_to "Title", documents_path( order: "title", docs: params[:docs], title: params[:title],author: params[:author], edition: params[:edition], anthology_id: params[:anthology_id] ) %>
-      </th>
-      <th><%= link_to "Author", documents_path( order: "author", docs: params[:docs], title: params[:title],author: params[:author], edition: params[:edition], anthology_id: params[:anthology_id] ) %>
-      </th>
-      <th><%= link_to "Created", documents_path( order: "created_at", docs: params[:docs], title: params[:title],author: params[:author], edition: params[:edition], anthology_id: params[:anthology_id] ) %>    </th>
+    <th>
+        <%= link_to "Title", documents_path( order: "title", docs: params[:docs], title: params[:title],author: params[:author], edition: params[:edition], anthology_id: params[:anthology_id] ) %>
+    </th>
+    <th>
+        <%= link_to "Author", documents_path( order: "author", docs: params[:docs], title: params[:title],author: params[:author], edition: params[:edition], anthology_id: params[:anthology_id] ) %>
+    </th>
+    <th>
+      <%= link_to "Created", documents_path( order: "created_at", docs: params[:docs], title: params[:title],author: params[:author], edition: params[:edition], anthology_id: params[:anthology_id] ) %>
+    </th>
     <th><%= ENV["CLASS_TERM_PLURAL"] %></th>
     <th>Status</th>
     <th>Actions</th>
   </tr>
   <% documents.each do |document| %>
     <tr>
-      <% if current_user.admin? || current_user.teacher? %>
-        <% if document.anthologies.include?(@anthology) %>
-          <td><div class="<%= "document_of_#{document.id}" %>" ><%= check_box_tag 'document_ids[]', document.id,  :checked => "checked" %></div></td>
-        <% else %>
-          <td><div class="<%= "document_of_#{document.id}"%>" ><%= check_box_tag 'document_ids[]',  document.id %></div></td>
-        <% end %>
-      <% end %>
       <td>
         <% if controller_name == 'anthologies' %>
           <%= link_to document.title, anthology_document_path(@anthology.friendly_id, document.friendly_id) %></td>
-    <% else %>
-      <%= link_to document.title, document_path(document.friendly_id) %></td>
-  <% end %>
-  <td>
-    <%= document.author %></td>
-  <td>
-    <%= document.created_at.strftime("%m/%d/%Y") %></td>
-  <td>
-    <% document.rep_group_list.each do |group| %>
-      <span class="label label-info">
-        <%= group %></span>
-    <% end %></td>
-  <td>
-    <% if can? :update, document %>
+        <% else %>
+          <%= link_to document.title, document_path(document.friendly_id) %>
+        <% end %>
+      </td>
+      <td>
+        <%= document.author %></td>
+      <td>
+        <%= document.created_at.strftime("%m/%d/%Y") %></td>
+      <td>
+        <% document.rep_group_list.each do |group| %>
+          <span class="label label-info">
+            <%= group %></span>
+        <% end %></td>
+      <td>
+      <% if can? :update, document %>
       <div class="btn-group" role="group" aria-label="document states">
 
         <% if document.draft? %>
@@ -94,7 +89,11 @@
         <% end %>
       <% end %>
       <% if document.anthologies.include?(@anthology) && current_user.admin? %>
-        <%= link_to 'Remove from anthology', { action: :remove_doc, controller: 'anthologies', anthology_id: @anthology.id, document_id: document.id }, method: :post, :class => 'btn btn-danger btn-sm' %>
+        <%= link_to 'Remove from anthology',
+            { action: :remove_doc, controller: 'anthologies', anthology_id: @anthology.id, document_id: document.id }, method: :post, :class => 'btn btn-danger btn-sm' %>
+      <% else %>
+        <%= link_to 'Assign to Anthology',
+          { action: :anthology_add, controller: 'documents', anthology: @anthology.id, document_ids: [document.id]}, method: :post, :class => 'btn btn-primary btn-sm' %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/documents/_document_table.html.erb
+++ b/app/views/documents/_document_table.html.erb
@@ -88,12 +88,14 @@
           <%= link_to 'Edit', edit_document_path(document), :class => 'btn btn-default btn-sm', data: { toggle: 'tooltip', placement: 'top', original_title: 'Only metadata are editable' } %>
         <% end %>
       <% end %>
-      <% if document.anthologies.include?(@anthology) && current_user.admin? %>
-        <%= link_to 'Remove from anthology',
-            { action: :remove_doc, controller: 'anthologies', anthology_id: @anthology.id, document_id: document.id }, method: :post, :class => 'btn btn-danger btn-sm' %>
-      <% else %>
-        <%= link_to 'Assign to Anthology',
-          { action: :anthology_add, controller: 'documents', anthology: @anthology.id, document_ids: [document.id]}, method: :post, :class => 'btn btn-primary btn-sm' %>
+      <% if controller_name == 'Anthologies' %>
+        <% if document.anthologies.include?(@anthology) && current_user.admin? %>
+          <%= link_to 'Remove from anthology',
+              { action: :remove_doc, controller: 'anthologies', anthology_id: @anthology.id, document_id: document.id }, method: :post, :class => 'btn btn-danger btn-sm' %>
+        <% else %>
+          <%= link_to 'Assign to Anthology',
+            { action: :anthology_add, controller: 'documents', anthology: @anthology.id, document_ids: [document.id]}, method: :post, :class => 'btn btn-primary btn-sm' %>
+        <% end %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -70,18 +70,6 @@
           <% unless @documents.blank? %>
             <%= form_tag(anthology_add_path, :method => "post") do %>
               <%= render partial: 'document_table', locals: { documents: @documents } %>
-              <% unless @anthologies.blank? %>
-              <%= button_tag "Add selected to anthology:", :class => 'btn btn-primary create-new-button',:name => nil%>
-              <select name="anthology" id="anthology">
-                <% @anthologies.each do |anthology| %>
-                  <% if anthology.id == @anthology.id %>
-                    <option selected="selected" value=<%= anthology.id %>><%= link_to anthology.name, documents_path(title: params[:title],author: params[:author], edition: params[:edition], anthology_id: anthology.id) %> </option>
-                  <% else %>
-                    <option value=<%= anthology.id %>><%= link_to anthology.name, documents_path(title: params[:title],author: params[:author], edition: params[:edition], anthology_id: anthology.id) %> </option>
-                  <% end %>
-                <% end %>
-              </select>
-            <% end %>
             <% end %>
           <% else %>
             <div class="container">

--- a/app/views/users/_user_table.html.erb
+++ b/app/views/users/_user_table.html.erb
@@ -21,7 +21,8 @@
         <%= user.email %></td>
       <td class="button-column">
         <% if @anthology.present? &&  user.anthologies.include?(@anthology) && @anthologies.include?(@anthology) %>
-          <%= link_to 'Remove from anthology', { action: :remove_user, controller: 'users', anthology_id: @anthology.id, user_id: user.id}, method: :post, :class => 'btn btn-danger btn-sm' %>
+          <%= link_to 'Remove from anthology',
+            { action: :remove_user, controller: 'users', anthology_id: @anthology.id, user_id: user.id}, method: :post, :class => 'btn btn-danger btn-sm' %>
         <% end %>
       <% end %>
 </table>

--- a/db/migrate/20200506054220_add_reg_group_to_user_and_document.rb
+++ b/db/migrate/20200506054220_add_reg_group_to_user_and_document.rb
@@ -1,0 +1,6 @@
+class AddRegGroupToUserAndDocument < ActiveRecord::Migration
+  def change
+    add_column :users, :rep_group, :string
+    add_column :documents, :rep_group, :string
+  end
+end


### PR DESCRIPTION
## What does this PR do?
1. Fix pagination issue on anthology show for users and and documents tabs.
2. User rep groups instead of a join table to add documents and users to anthologies

## How to test?
1. Login to http://cove-staging.herokuapp.com/ (use your admin account)
2. On the dashboard page click on the Anthologies page at http://cove-staging.herokuapp.com/anthologies
3. Now click on any anthology from list for detail view
4. Click on the users tab
5. Search for "a" in the fullname part of the user tab
6. Make sure the pagination is there and you are able to go to any of the pages
7. Add any user to an anthology and make sure you see them on the all tab (within the users tab)
8. Try to remove any user in the all tab from the anthology and make sure that user is not in the all tab
9. Now click on the documents tab
10. Search for "a" in the title part of the documents tab
11. Make sure the pagination is there and you are able to go to any of the pages
12. Add any document to an anthology and make sure you see the document on the all tab (within the users tab)
13. Try to remove any document in the all tab from the anthology and make sure that document is not in the all tab