### PR TITLE
Change columns on the anthology show view documents list

### DIFF
--- a/app/views/anthologies/_documents_tab.html.erb
+++ b/app/views/anthologies/_documents_tab.html.erb
@@ -16,13 +16,5 @@
               </div>
             </div>
           <% end %>
-          <%= form_tag(anthology_path(id: anthology.friendly_id, docs: "search_results"), :method => "get", class: 'navbar-form navbar-left') do %>
-            <div class="input-group">
-              <%= search_field_tag :edition, params[:edition], placeholder: "Edition", class: "form-control" %>
-              <div class="input-group-btn">
-                <%= button_tag "Search", :class => 'btn btn-info',:name => nil %>
-              </div>
-            </div>
-          <% end %>
         </div>
       </div>

--- a/app/views/documents/_document_table.html.erb
+++ b/app/views/documents/_document_table.html.erb
@@ -9,8 +9,11 @@
     <th>
       <%= link_to "Created", documents_path( order: "created_at", docs: params[:docs], title: params[:title],author: params[:author], edition: params[:edition], anthology_id: params[:anthology_id] ) %>
     </th>
-<!--    <th><%#= ENV["CLASS_TERM_PLURAL"] %></th>-->
-    <% if current_user.admin? %>
+    <% if %w[anthologies].include?(controller_name) %>
+      <th>Vetted</th>
+    <% end %>
+    <% if %w[anthologies].exclude?(controller_name) %>
+      <th><%= ENV["CLASS_TERM_PLURAL"] %></th>
       <th>Status</th>
     <% end %>
     <th>Actions</th>
@@ -28,55 +31,60 @@
         <%= document.author %></td>
       <td>
         <%= document.created_at.strftime("%m/%d/%Y") %></td>
-<!--      <td>-->
-        <%# document.rep_group_list.each do |group| %>
-<!--          <span class="label label-info">-->
-<!--            <%#= group %></span>-->
-<!--        <%# end %></td>-->
-    <% if current_user.admin? %>
-      <td>
-        <% if can? :update, document %>
-          <div class="btn-group" role="group" aria-label="document states">
+      <% if %w[anthologies].include?(controller_name) %>
+        <td>
+          <%= document.vetted.present?.to_s.capitalize %>
+        </td>
+      <% end %>
+      <% if %w[anthologies].exclude?(controller_name) %>
+        <td>
+          <% document.rep_group_list.each do |group| %>
+        <span class="label label-info">
+          <%= group %></span>
+          <% end %></td>
+        <td>
+          <% if can? :update, document %>
+            <div class="btn-group" role="group" aria-label="document states">
 
-            <% if document.draft? %>
-              <%= link_to 'Editable', "#", :class => 'btn btn-default btn-sm active' %>
-            <% else %>
-              <%= link_to 'Editable', "#", :class => 'btn btn-default btn-sm disabled' %>
-            <% end %>
-
-
-            <% if document.annotatable? %>
-              <%= link_to 'Annotatable', document_annotatable_path(document), method: :post, :class => 'btn btn-default btn-sm active' %>
-            <% else %>
-              <%= link_to 'Annotatable', document_annotatable_path(document), method: :post, :class => 'btn btn-default btn-sm' %>
-            <% end %>
+              <% if document.draft? %>
+                <%= link_to 'Editable', "#", :class => 'btn btn-default btn-sm active' %>
+              <% else %>
+                <%= link_to 'Editable', "#", :class => 'btn btn-default btn-sm disabled' %>
+              <% end %>
 
 
-            <% if document.review? %>
-              <%= link_to 'Reviewable', document_review_path(document), method: :post, :class => 'btn btn-default btn-sm active' %>
-            <% else %>
-              <%= link_to 'Reviewable', document_review_path(document), method: :post, :class => 'btn btn-default btn-sm' %>
-            <% end %>
+              <% if document.annotatable? %>
+                <%= link_to 'Annotatable', document_annotatable_path(document), method: :post, :class => 'btn btn-default btn-sm active' %>
+              <% else %>
+                <%= link_to 'Annotatable', document_annotatable_path(document), method: :post, :class => 'btn btn-default btn-sm' %>
+              <% end %>
 
 
-            <% if document.published? %>
-              <%= link_to 'Publishable', document_publish_path(document), method: :post, :class => 'btn btn-default btn-sm active' %>
-            <% else %>
-              <%= link_to 'Publishable', document_publish_path(document), method: :post, :class => 'btn btn-default btn-sm' %>
-            <% end %>
+              <% if document.review? %>
+                <%= link_to 'Reviewable', document_review_path(document), method: :post, :class => 'btn btn-default btn-sm active' %>
+              <% else %>
+                <%= link_to 'Reviewable', document_review_path(document), method: :post, :class => 'btn btn-default btn-sm' %>
+              <% end %>
 
 
-            <% if document.archived? %>
-              <%= link_to 'Hidden', document_archive_path(document), method: :post, :class => 'btn btn-default btn-sm active' %>
-            <% else %>
-              <%= link_to 'Hidden', document_archive_path(document), method: :post, :class => 'btn btn-default btn-sm' %>
-            <% end %>
-          </div>
-        <% else %>
-          <%= document.state %>
-        <% end %>
-      </td>
-    <% end %>
+              <% if document.published? %>
+                <%= link_to 'Publishable', document_publish_path(document), method: :post, :class => 'btn btn-default btn-sm active' %>
+              <% else %>
+                <%= link_to 'Publishable', document_publish_path(document), method: :post, :class => 'btn btn-default btn-sm' %>
+              <% end %>
+
+
+              <% if document.archived? %>
+                <%= link_to 'Hidden', document_archive_path(document), method: :post, :class => 'btn btn-default btn-sm active' %>
+              <% else %>
+                <%= link_to 'Hidden', document_archive_path(document), method: :post, :class => 'btn btn-default btn-sm' %>
+              <% end %>
+            </div>
+          <% else %>
+            <%= document.state %>
+          <% end %>
+        </td>
+      <% end %>
   <td class="button-column">
     <% if can? :update, document %>
       <% if document.draft? %>
@@ -102,7 +110,7 @@
     <% end %>
   <% end %>
   </td>
-  </tr>
+</tr>
 </table>
 <script type="text/javascript">
   $(function () {

--- a/app/views/documents/_document_table.html.erb
+++ b/app/views/documents/_document_table.html.erb
@@ -9,8 +9,10 @@
     <th>
       <%= link_to "Created", documents_path( order: "created_at", docs: params[:docs], title: params[:title],author: params[:author], edition: params[:edition], anthology_id: params[:anthology_id] ) %>
     </th>
-    <th><%= ENV["CLASS_TERM_PLURAL"] %></th>
-    <th>Status</th>
+<!--    <th><%#= ENV["CLASS_TERM_PLURAL"] %></th>-->
+    <% if current_user.admin? %>
+      <th>Status</th>
+    <% end %>
     <th>Actions</th>
   </tr>
   <% documents.each do |document| %>
@@ -26,53 +28,55 @@
         <%= document.author %></td>
       <td>
         <%= document.created_at.strftime("%m/%d/%Y") %></td>
+<!--      <td>-->
+        <%# document.rep_group_list.each do |group| %>
+<!--          <span class="label label-info">-->
+<!--            <%#= group %></span>-->
+<!--        <%# end %></td>-->
+    <% if current_user.admin? %>
       <td>
-        <% document.rep_group_list.each do |group| %>
-          <span class="label label-info">
-            <%= group %></span>
-        <% end %></td>
-      <td>
-      <% if can? :update, document %>
-      <div class="btn-group" role="group" aria-label="document states">
+        <% if can? :update, document %>
+          <div class="btn-group" role="group" aria-label="document states">
 
-        <% if document.draft? %>
-          <%= link_to 'Editable', "#", :class => 'btn btn-default btn-sm active' %>
+            <% if document.draft? %>
+              <%= link_to 'Editable', "#", :class => 'btn btn-default btn-sm active' %>
+            <% else %>
+              <%= link_to 'Editable', "#", :class => 'btn btn-default btn-sm disabled' %>
+            <% end %>
+
+
+            <% if document.annotatable? %>
+              <%= link_to 'Annotatable', document_annotatable_path(document), method: :post, :class => 'btn btn-default btn-sm active' %>
+            <% else %>
+              <%= link_to 'Annotatable', document_annotatable_path(document), method: :post, :class => 'btn btn-default btn-sm' %>
+            <% end %>
+
+
+            <% if document.review? %>
+              <%= link_to 'Reviewable', document_review_path(document), method: :post, :class => 'btn btn-default btn-sm active' %>
+            <% else %>
+              <%= link_to 'Reviewable', document_review_path(document), method: :post, :class => 'btn btn-default btn-sm' %>
+            <% end %>
+
+
+            <% if document.published? %>
+              <%= link_to 'Publishable', document_publish_path(document), method: :post, :class => 'btn btn-default btn-sm active' %>
+            <% else %>
+              <%= link_to 'Publishable', document_publish_path(document), method: :post, :class => 'btn btn-default btn-sm' %>
+            <% end %>
+
+
+            <% if document.archived? %>
+              <%= link_to 'Hidden', document_archive_path(document), method: :post, :class => 'btn btn-default btn-sm active' %>
+            <% else %>
+              <%= link_to 'Hidden', document_archive_path(document), method: :post, :class => 'btn btn-default btn-sm' %>
+            <% end %>
+          </div>
         <% else %>
-          <%= link_to 'Editable', "#", :class => 'btn btn-default btn-sm disabled' %>
+          <%= document.state %>
         <% end %>
-
-
-        <% if document.annotatable? %>
-          <%= link_to 'Annotatable', document_annotatable_path(document), method: :post, :class => 'btn btn-default btn-sm active' %>
-        <% else %>
-          <%= link_to 'Annotatable', document_annotatable_path(document), method: :post, :class => 'btn btn-default btn-sm' %>
-        <% end %>
-
-
-        <% if document.review? %>
-          <%= link_to 'Reviewable', document_review_path(document), method: :post, :class => 'btn btn-default btn-sm active' %>
-        <% else %>
-          <%= link_to 'Reviewable', document_review_path(document), method: :post, :class => 'btn btn-default btn-sm' %>
-        <% end %>
-
-
-        <% if document.published? %>
-          <%= link_to 'Publishable', document_publish_path(document), method: :post, :class => 'btn btn-default btn-sm active' %>
-        <% else %>
-          <%= link_to 'Publishable', document_publish_path(document), method: :post, :class => 'btn btn-default btn-sm' %>
-        <% end %>
-
-
-        <% if document.archived? %>
-          <%= link_to 'Hidden', document_archive_path(document), method: :post, :class => 'btn btn-default btn-sm active' %>
-        <% else %>
-          <%= link_to 'Hidden', document_archive_path(document), method: :post, :class => 'btn btn-default btn-sm' %>
-        <% end %>
-      </div>
-    <% else %>
-      <%= document.state %>
+      </td>
     <% end %>
-  </td>
   <td class="button-column">
     <% if can? :update, document %>
       <% if document.draft? %>
@@ -88,17 +92,17 @@
           <%= link_to 'Edit', edit_document_path(document), :class => 'btn btn-default btn-sm', data: { toggle: 'tooltip', placement: 'top', original_title: 'Only metadata are editable' } %>
         <% end %>
       <% end %>
-      <% if controller_name == 'anthologies' && current_user.admin? %>
-        <% if document.anthologies.include?(@anthology) && current_user.admin? %>
-          <%= link_to 'Remove from anthology',
-              { action: :remove_doc, controller: 'anthologies', anthology_id: @anthology.id, document_id: document.id }, method: :post, :class => 'btn btn-danger btn-sm' %>
-        <% else %>
-          <%= link_to 'Assign to Anthology',
-            { action: :anthology_add, controller: 'documents', anthology: @anthology.id, document_ids: [document.id]}, method: :post, :class => 'btn btn-primary btn-sm' %>
-        <% end %>
+      <% if document.anthologies.include?(@anthology) && current_user.admin? %>
+        <%= link_to 'Remove from anthology',
+            { action: :remove_doc, controller: 'anthologies', anthology_id: @anthology.id, document_id: document.id }, method: :post, :class => 'btn btn-danger btn-sm' %>
+      <% else %>
+        <%= link_to 'Assign to Anthology',
+          { action: :anthology_add, controller: 'documents', anthology: @anthology.id, document_ids: [document.id]}, method: :post, :class => 'btn btn-primary btn-sm' %>
       <% end %>
     <% end %>
   <% end %>
+  </td>
+  </tr>
 </table>
 <script type="text/javascript">
   $(function () {

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -19,14 +19,14 @@
       </div>
     </div>
   <% end %>
-  <%= form_tag(documents_path, :method => "get", class: 'navbar-form navbar-left') do %>
-    <div class="input-group">
-      <%= search_field_tag :edition, params[:edition], placeholder: "Edition", class: "form-control" %>
-      <div class="input-group-btn">
-        <%= button_tag "Search", :class => 'btn btn-info',:name => nil%>
-      </div>
-    </div>
-  <% end %>
+  <%#= form_tag(documents_path, :method => "get", class: 'navbar-form navbar-left') do %>
+<!--    <div class="input-group">-->
+      <%#= search_field_tag :edition, params[:edition], placeholder: "Edition", class: "form-control" %>
+<!--      <div class="input-group-btn">-->
+        <%#= button_tag "Search", :class => 'btn btn-info',:name => nil%>
+<!--      </div>-->
+<!--    </div>-->
+  <%# end %>
 </div>
 <div class="row">
   <div class="col-md-12">

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -19,14 +19,14 @@
       </div>
     </div>
   <% end %>
-  <%#= form_tag(documents_path, :method => "get", class: 'navbar-form navbar-left') do %>
-<!--    <div class="input-group">-->
-      <%#= search_field_tag :edition, params[:edition], placeholder: "Edition", class: "form-control" %>
-<!--      <div class="input-group-btn">-->
-        <%#= button_tag "Search", :class => 'btn btn-info',:name => nil%>
-<!--      </div>-->
-<!--    </div>-->
-  <%# end %>
+  <%= form_tag(documents_path, :method => "get", class: 'navbar-form navbar-left') do %>
+    <div class="input-group">
+      <%= search_field_tag :edition, params[:edition], placeholder: "Edition", class: "form-control" %>
+      <div class="input-group-btn">
+        <%= button_tag "Search", :class => 'btn btn-info',:name => nil%>
+      </div>
+    </div>
+  <% end %>
 </div>
 <div class="row">
   <div class="col-md-12">


### PR DESCRIPTION
## What does this PR do?
1. Removed the editions column on anthology show
2. Added a vetted column on anthology show
3. Status column on anthology show is only available to admins

## How to test?
1. Login using your admin account
2. Go to the  http://cove-staging.herokuapp.com/anthologies
3. Click on an anthology
4. The Editions search and table column should be entirely gone.
5. The Status column must be present.
6. A vetted column should also be present.
7. Logout and Login as a non-admin.
8. Repeat step 2 and 3
9. The status column should not be present