### PR TITLE
Document show and anthology show ui fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ group :development do
   gem 'meta_request'#, '0.2.1'
   gem 'highline'
   gem 'figaro'
+  gem 'byebug'
 end
 
 group :assets do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,6 +109,7 @@ GEM
     bourbon (6.0.0)
       thor (~> 0.19)
     builder (3.2.4)
+    byebug (10.0.2)
     cancancan (1.17.0)
     carrierwave (1.3.1)
       activemodel (>= 4.0.0)
@@ -589,6 +590,7 @@ DEPENDENCIES
   aws-sdk-s3
   babosa
   backbone-on-rails
+  byebug
   cancancan (~> 1.10)
   carrierwave
   coffee-rails

--- a/app/admin/tenants.rb
+++ b/app/admin/tenants.rb
@@ -1,5 +1,30 @@
 ActiveAdmin.register Tenant do
-  permit_params :domain, :database_name, :mel_catalog_enabled, :mel_catalog_url, :annotation_categories_enabled
+  permit_params :domain, :database_name, :mel_catalog_enabled, :mel_catalog_url, :annotation_categories_enabled, :site_name, :welcome_message, :welcome_blurb, :site_color, :brand, :wp_url, :wp_auth_key, :wp_auth_secret
+
+  scope :all, :default => true
+
+  filter :domain
+  filter :mel_catalog_enabled
+  filter :mel_catalog_url
+  filter :annotation_categories_enabled
+  filter :database_name
+  filter :site_name
+  filter :welcome_message
+  filter :site_color
+  filter :brand
+
+  index do
+    selectable_column
+    column "Domain", :domain
+    column "Mel Catalog", :mel_catalog_enabled
+    column "Mel Catalog Url", :mel_catalog_url
+    column "DB name", :database_name
+    column "Site Name", :site_name
+    column "Welcome Message", :welcome_message
+    column "Site Color", :site_color
+    column "Brand", :brand
+    actions
+  end
 
   form do |f|
     f.inputs "Tenant Details" do
@@ -8,6 +33,14 @@ ActiveAdmin.register Tenant do
       f.input :mel_catalog_url, :as => :string, label: 'The full url, ex - "http://mel-catalog.herokuapp.com/api/"'
       f.input :annotation_categories_enabled, :as => :boolean, label: 'Enables Annotation Categories'
       f.input :database_name, :as => :string, label: 'The internal database name, ex - "app":'
+      f.input :site_name, :as => :string, label: 'Enter Site name:'
+      f.input :welcome_message, :as => :string, label: 'Welcome message for this tenant:'
+      f.input :welcome_blurb, :as => :string, label: 'Welcome blurb for this tenant:'
+      f.input :site_color, :as => :color, label: 'Customize a site color(Hex Code):'
+      f.input :brand, :as => :string, label: 'Enter the brand'
+      f.input :wp_url, :as => :string, label: 'Enter WordPress hosted Url'
+      f.input :wp_auth_key, :as => :string, label: 'Enter WordPress Auth Key'
+      f.input :wp_auth_secret, :as => :string, label: 'Enter WordPress Auth Secret'
     end
     f.actions do
       f.action :submit

--- a/app/controllers/anthologies_controller.rb
+++ b/app/controllers/anthologies_controller.rb
@@ -102,7 +102,9 @@ class AnthologiesController < ApplicationController
   def remove_doc
     respond_to do |format|
       @anthology = Anthology.find(params[:anthology_id])
+      Rails.logger.info "**** entering remove doc"
       @document = Document.find(params[:document_id])
+      Rails.logger.info "The doc is #{@document.inspect}"
 
       if @anthology.present? && @document.present? && @anthology.documents.delete(@document)
         @document.rep_group_list.remove(@anthology.slug)
@@ -117,14 +119,16 @@ class AnthologiesController < ApplicationController
   def remove_user
     respond_to do |format|
       @anthology = Anthology.find(params[:anthology_id])
+      Rails.logger.info "**** removing user"
       @user = User.find(params[:user_id])
+      Rails.logger.info "The user is #{@user.inspect}"
       @searched_name = (params[:name] || [])
       @searched_email = (params[:email] || [])
 
       if @anthology.present? && @user.present? && @anthology.users.delete(@user)
         @user.rep_group_list.remove(@anthology.slug)
         @user.save
-        format.html {redirect_to anthology_path(@anthology, tab: "users", name: @searched_name, email: @searched_email), tab: 'users', notice: "The user #{@user.fullname} was successfully removed from this anthology"}
+        format.html {redirect_to anthology_path(@anthology, tab: "users", name: @searched_name, email: @searched_email), tab: 'users', notice: "The user #{@user.full_name} was successfully removed from this anthology"}
       else
         format.html { redirect_to anthologies_path(@anthology, tab: "users", name: @searched_name, email: @searched_email), error: "There was a problem removing the user from this anthology" }
       end
@@ -134,7 +138,9 @@ class AnthologiesController < ApplicationController
   def add_user
     respond_to do |format|
       @anthology = Anthology.find(params[:anthology_id])
+      Rails.logger.info "**** adding user"
       @user = User.find(params[:user_id])
+      Rails.logger.info "The user is #{@user.inspect}"
       @searched_name = (params[:name] || [])
       @searched_email = (params[:email] || [])
 
@@ -142,7 +148,7 @@ class AnthologiesController < ApplicationController
         @anthology.users << @user
         @user.rep_group_list.add(@anthology.slug)
         @user.save
-        format.html {redirect_to anthology_path(@anthology, tab: "users", name: @searched_name, email: @searched_email), notice: "The user #{@user.fullname} was successfully added to this anthology"}
+        format.html {redirect_to anthology_path(@anthology, tab: "users", name: @searched_name, email: @searched_email), notice: "The user #{@user.email} was successfully added to this anthology"}
       else
         format.html { redirect_to anthologies_path(@anthology, tab: "users", name: @searched_name, email: @searched_email), error: "There was a problem adding the user to this anthology" }
       end
@@ -174,7 +180,7 @@ class AnthologiesController < ApplicationController
 
     respond_to do |format|
       if @anthology.update_attributes(anthology_params)
-        format.html { redirect_to anthologies_url, notice: 'Anthology was successfully updated.' }
+        format.html { redirect_to @anthology, notice: 'Anthology was successfully updated.' }
         format.json { head :no_content }
       else
         format.html { redirect_to edit_anthology_url(id: @anthology.friendly_id), alert: @anthology.error_messages}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -36,11 +36,11 @@ class ApplicationController < ActionController::Base
   end
 
   def set_domain_config
-    $DOMAIN_CONFIG = DOMAIN_CONFIGS['public']
-    if (request.subdomain.present? && DOMAIN_CONFIGS[request.subdomain].present?)
-      $DOMAIN_CONFIG = DOMAIN_CONFIGS[request.subdomain]
+    $DOMAIN_CONFIG = set_domain_configs('public')
+    if (request.subdomain.present? && set_domain_configs(request.subdomain).present?)
+      $DOMAIN_CONFIG = set_domain_configs(request.subdomain)
     else
-      $DOMAIN_CONFIG = DOMAIN_CONFIGS['default']
+      $DOMAIN_CONFIG = set_domain_configs('default')
     end
   end
 
@@ -51,4 +51,8 @@ class ApplicationController < ActionController::Base
     devise_parameter_sanitizer.for(:sign_up) << [:firstname, :lastname, :rep_group_list, :agreement, :affiliation]
   end
 
+  private
+  def set_domain_configs(args)
+    Tenant.find_by(database_name: args).as_json
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,7 +14,7 @@ class ApplicationController < ActionController::Base
           },
           ENV["API_SECRET"]
       )
-      user_url(user)
+      stored_location_for(user) || super
   end
 
   def authenticate

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -1,7 +1,6 @@
 class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def wordpress_hosted
     @user = User.find_for_wordpress_oauth2(request.env["omniauth.auth"], current_user)
-
     if @user.persisted?
       flash[:notice] = I18n.t "devise.omniauth_callbacks.success", :kind => "NAVSA"
       sign_in_and_redirect @user, :event => :authentication #this will throw if @user is not activated
@@ -10,4 +9,14 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
       redirect_to new_user_registration_url
     end
   end
+
+  def setup
+    @tenant = Tenant.current_tenant
+    Rails.logger.info("**********Setup Started************")
+    request.env['omniauth.strategy'].options[:client_id] = @tenant.wp_auth_key || ENV["WP_AUTH_KEY"]
+    request.env['omniauth.strategy'].options[:client_secret] = @tenant.wp_auth_secret || ENV["WP_AUTH_SECRET"]
+    request.env['omniauth.strategy'].options[:client_options].site = @tenant.wp_url || ENV["WP_URL"]
+    render :text => "Setup complete.", :status => 404
+  end
+
 end

--- a/app/views/anthologies/_documents_tab.html.erb
+++ b/app/views/anthologies/_documents_tab.html.erb
@@ -16,13 +16,5 @@
               </div>
             </div>
           <% end %>
-          <%= form_tag(anthology_path(id: anthology.friendly_id, docs: "search_results"), :method => "get", class: 'navbar-form navbar-left') do %>
-            <div class="input-group">
-              <%= search_field_tag :edition, params[:edition], placeholder: "Edition", class: "form-control" %>
-              <div class="input-group-btn">
-                <%= button_tag "Search", :class => 'btn btn-info',:name => nil %>
-              </div>
-            </div>
-          <% end %>
         </div>
       </div>

--- a/app/views/anthologies/_form.html.erb
+++ b/app/views/anthologies/_form.html.erb
@@ -11,6 +11,11 @@
           <%= f.text_area :description, :class => 'form-control' %>
         </div>
         <div class="form-group">
+          <% unless @anthology.banner.blank? %>
+            <div class="container" >
+              <%= link_to image_tag(@anthology.banner.url(:medium), class: 'media-object', style: "padding-top:15px;"), @anthology.banner.url(:medium), target: '_blank'  %>
+            </div>
+          <% end %>
           <%= f.label :banner %>
           <%= f.file_field :banner, class: 'form-control' %>
         <i>The banner should be a png, jpg, or jpeg and should be less than 1 MB and at least 1100 # 250 pixels</i>

--- a/app/views/anthologies/edit.html.erb
+++ b/app/views/anthologies/edit.html.erb
@@ -4,7 +4,7 @@
   <div class="col-md-12">
     <div class="panel panel-default" id="document-form">
       <div class="panel-heading">
-        <span class="panel-title">Edit Anthology(<%= @anthology.name %>)</span>
+        <span class="panel-title">Edit Anthology</span>
       </div>
       <% if @anthology.user == current_user %>
       <%= render partial: 'form' %>

--- a/app/views/documents/_document_table.html.erb
+++ b/app/views/documents/_document_table.html.erb
@@ -26,6 +26,8 @@
     <% end %>
     <% if %w[anthologies].exclude?(controller_name) and current_user.admin?%>
       <th><%= ENV["CLASS_TERM_PLURAL"] %></th>
+    <% end %>
+    <% if current_user.admin?%>
       <th>Status</th>
     <% end %>
     <th>Actions</th>
@@ -51,52 +53,54 @@
       <% if %w[anthologies].exclude?(controller_name) and current_user.admin?%>
         <td>
           <% document.rep_group_list.each do |group| %>
-        <span class="label label-info">
+            <span class="label label-info">
           <%= group %></span>
           <% end %></td>
-        <td>
-          <% if can? :update, document %>
-            <div class="btn-group" role="group" aria-label="document states">
+        <% end %>
+        <% if current_user.admin? %>
+          <td>
+            <% if can? :update, document %>
+              <div class="btn-group" role="group" aria-label="document states">
 
-              <% if document.draft? %>
-                <%= link_to 'Editable', "#", :class => 'btn btn-default btn-sm active' %>
-              <% else %>
-                <%= link_to 'Editable', "#", :class => 'btn btn-default btn-sm disabled' %>
-              <% end %>
-
-
-              <% if document.annotatable? %>
-                <%= link_to 'Annotatable', document_annotatable_path(document), method: :post, :class => 'btn btn-default btn-sm active' %>
-              <% else %>
-                <%= link_to 'Annotatable', document_annotatable_path(document), method: :post, :class => 'btn btn-default btn-sm' %>
-              <% end %>
+                <% if document.draft? %>
+                  <%= link_to 'Editable', "#", :class => 'btn btn-default btn-sm active' %>
+                <% else %>
+                  <%= link_to 'Editable', "#", :class => 'btn btn-default btn-sm disabled' %>
+                <% end %>
 
 
-              <% if document.review? %>
-                <%= link_to 'Reviewable', document_review_path(document), method: :post, :class => 'btn btn-default btn-sm active' %>
-              <% else %>
-                <%= link_to 'Reviewable', document_review_path(document), method: :post, :class => 'btn btn-default btn-sm' %>
-              <% end %>
+                <% if document.annotatable? %>
+                  <%= link_to 'Annotatable', document_annotatable_path(document), method: :post, :class => 'btn btn-default btn-sm active' %>
+                <% else %>
+                  <%= link_to 'Annotatable', document_annotatable_path(document), method: :post, :class => 'btn btn-default btn-sm' %>
+                <% end %>
 
 
-              <% if document.published? %>
-                <%= link_to 'Publishable', document_publish_path(document), method: :post, :class => 'btn btn-default btn-sm active' %>
-              <% else %>
-                <%= link_to 'Publishable', document_publish_path(document), method: :post, :class => 'btn btn-default btn-sm' %>
-              <% end %>
+                <% if document.review? %>
+                  <%= link_to 'Reviewable', document_review_path(document), method: :post, :class => 'btn btn-default btn-sm active' %>
+                <% else %>
+                  <%= link_to 'Reviewable', document_review_path(document), method: :post, :class => 'btn btn-default btn-sm' %>
+                <% end %>
 
 
-              <% if document.archived? %>
-                <%= link_to 'Hidden', document_archive_path(document), method: :post, :class => 'btn btn-default btn-sm active' %>
-              <% else %>
-                <%= link_to 'Hidden', document_archive_path(document), method: :post, :class => 'btn btn-default btn-sm' %>
-              <% end %>
-            </div>
-          <% else %>
-            <%= document.state %>
-          <% end %>
-        </td>
-      <% end %>
+                <% if document.published? %>
+                  <%= link_to 'Publishable', document_publish_path(document), method: :post, :class => 'btn btn-default btn-sm active' %>
+                <% else %>
+                  <%= link_to 'Publishable', document_publish_path(document), method: :post, :class => 'btn btn-default btn-sm' %>
+                <% end %>
+
+
+                <% if document.archived? %>
+                  <%= link_to 'Hidden', document_archive_path(document), method: :post, :class => 'btn btn-default btn-sm active' %>
+                <% else %>
+                  <%= link_to 'Hidden', document_archive_path(document), method: :post, :class => 'btn btn-default btn-sm' %>
+                <% end %>
+              </div>
+            <% else %>
+              <%= document.state %>
+            <% end %>
+          </td>
+        <% end %>
   <td class="button-column">
     <% if can? :update, document %>
       <% if document.draft? %>

--- a/app/views/documents/_document_table.html.erb
+++ b/app/views/documents/_document_table.html.erb
@@ -1,18 +1,30 @@
 <table class="table table-striped table-bordered">
   <tr>
     <th>
+      <% if %w[documents].include?(controller_name) %>
         <%= link_to "Title", documents_path( order: "title", docs: params[:docs], title: params[:title],author: params[:author], edition: params[:edition], anthology_id: params[:anthology_id] ) %>
+      <% else %>
+        <%= link_to "Title", anthology_path(@anthology, order: "title") %>
+      <% end %>
     </th>
     <th>
+      <% if %w[documents].include?(controller_name) %>
         <%= link_to "Author", documents_path( order: "author", docs: params[:docs], title: params[:title],author: params[:author], edition: params[:edition], anthology_id: params[:anthology_id] ) %>
+      <% else %>
+        <%= link_to "Author", anthology_path(@anthology, order: "author") %>
+    <% end %>
     </th>
     <th>
-      <%= link_to "Created", documents_path( order: "created_at", docs: params[:docs], title: params[:title],author: params[:author], edition: params[:edition], anthology_id: params[:anthology_id] ) %>
+      <% if %w[documents].include?(controller_name) %>
+        <%= link_to "Created", documents_path( order: "created_at", docs: params[:docs], title: params[:title],author: params[:author], edition: params[:edition], anthology_id: params[:anthology_id] ) %>
+      <% else %>
+        <%= link_to "Created", anthology_path(@anthology, order: "created_at") %>
+    <% end %>
     </th>
     <% if %w[anthologies].include?(controller_name) %>
       <th>Vetted</th>
     <% end %>
-    <% if %w[anthologies].exclude?(controller_name) %>
+    <% if %w[anthologies].exclude?(controller_name) and current_user.admin?%>
       <th><%= ENV["CLASS_TERM_PLURAL"] %></th>
       <th>Status</th>
     <% end %>
@@ -36,7 +48,7 @@
           <%= document.vetted.present?.to_s.capitalize %>
         </td>
       <% end %>
-      <% if %w[anthologies].exclude?(controller_name) %>
+      <% if %w[anthologies].exclude?(controller_name) and current_user.admin?%>
         <td>
           <% document.rep_group_list.each do |group| %>
         <span class="label label-info">

--- a/app/views/documents/_document_table.html.erb
+++ b/app/views/documents/_document_table.html.erb
@@ -9,8 +9,11 @@
     <th>
       <%= link_to "Created", documents_path( order: "created_at", docs: params[:docs], title: params[:title],author: params[:author], edition: params[:edition], anthology_id: params[:anthology_id] ) %>
     </th>
-<!--    <th><%#= ENV["CLASS_TERM_PLURAL"] %></th>-->
-    <% if current_user.admin? %>
+    <% if %w[anthologies].include?(controller_name) %>
+      <th>Vetted</th>
+    <% end %>
+    <% if %w[anthologies].exclude?(controller_name) %>
+      <th><%= ENV["CLASS_TERM_PLURAL"] %></th>
       <th>Status</th>
     <% end %>
     <th>Actions</th>
@@ -28,55 +31,60 @@
         <%= document.author %></td>
       <td>
         <%= document.created_at.strftime("%m/%d/%Y") %></td>
-<!--      <td>-->
-        <%# document.rep_group_list.each do |group| %>
-<!--          <span class="label label-info">-->
-<!--            <%#= group %></span>-->
-<!--        <%# end %></td>-->
-    <% if current_user.admin? %>
-      <td>
-        <% if can? :update, document %>
-          <div class="btn-group" role="group" aria-label="document states">
+      <% if %w[anthologies].include?(controller_name) %>
+        <td>
+          <%= document.vetted.present?.to_s.capitalize %>
+        </td>
+      <% end %>
+      <% if %w[anthologies].exclude?(controller_name) %>
+        <td>
+          <% document.rep_group_list.each do |group| %>
+        <span class="label label-info">
+          <%= group %></span>
+          <% end %></td>
+        <td>
+          <% if can? :update, document %>
+            <div class="btn-group" role="group" aria-label="document states">
 
-            <% if document.draft? %>
-              <%= link_to 'Editable', "#", :class => 'btn btn-default btn-sm active' %>
-            <% else %>
-              <%= link_to 'Editable', "#", :class => 'btn btn-default btn-sm disabled' %>
-            <% end %>
-
-
-            <% if document.annotatable? %>
-              <%= link_to 'Annotatable', document_annotatable_path(document), method: :post, :class => 'btn btn-default btn-sm active' %>
-            <% else %>
-              <%= link_to 'Annotatable', document_annotatable_path(document), method: :post, :class => 'btn btn-default btn-sm' %>
-            <% end %>
+              <% if document.draft? %>
+                <%= link_to 'Editable', "#", :class => 'btn btn-default btn-sm active' %>
+              <% else %>
+                <%= link_to 'Editable', "#", :class => 'btn btn-default btn-sm disabled' %>
+              <% end %>
 
 
-            <% if document.review? %>
-              <%= link_to 'Reviewable', document_review_path(document), method: :post, :class => 'btn btn-default btn-sm active' %>
-            <% else %>
-              <%= link_to 'Reviewable', document_review_path(document), method: :post, :class => 'btn btn-default btn-sm' %>
-            <% end %>
+              <% if document.annotatable? %>
+                <%= link_to 'Annotatable', document_annotatable_path(document), method: :post, :class => 'btn btn-default btn-sm active' %>
+              <% else %>
+                <%= link_to 'Annotatable', document_annotatable_path(document), method: :post, :class => 'btn btn-default btn-sm' %>
+              <% end %>
 
 
-            <% if document.published? %>
-              <%= link_to 'Publishable', document_publish_path(document), method: :post, :class => 'btn btn-default btn-sm active' %>
-            <% else %>
-              <%= link_to 'Publishable', document_publish_path(document), method: :post, :class => 'btn btn-default btn-sm' %>
-            <% end %>
+              <% if document.review? %>
+                <%= link_to 'Reviewable', document_review_path(document), method: :post, :class => 'btn btn-default btn-sm active' %>
+              <% else %>
+                <%= link_to 'Reviewable', document_review_path(document), method: :post, :class => 'btn btn-default btn-sm' %>
+              <% end %>
 
 
-            <% if document.archived? %>
-              <%= link_to 'Hidden', document_archive_path(document), method: :post, :class => 'btn btn-default btn-sm active' %>
-            <% else %>
-              <%= link_to 'Hidden', document_archive_path(document), method: :post, :class => 'btn btn-default btn-sm' %>
-            <% end %>
-          </div>
-        <% else %>
-          <%= document.state %>
-        <% end %>
-      </td>
-    <% end %>
+              <% if document.published? %>
+                <%= link_to 'Publishable', document_publish_path(document), method: :post, :class => 'btn btn-default btn-sm active' %>
+              <% else %>
+                <%= link_to 'Publishable', document_publish_path(document), method: :post, :class => 'btn btn-default btn-sm' %>
+              <% end %>
+
+
+              <% if document.archived? %>
+                <%= link_to 'Hidden', document_archive_path(document), method: :post, :class => 'btn btn-default btn-sm active' %>
+              <% else %>
+                <%= link_to 'Hidden', document_archive_path(document), method: :post, :class => 'btn btn-default btn-sm' %>
+              <% end %>
+            </div>
+          <% else %>
+            <%= document.state %>
+          <% end %>
+        </td>
+      <% end %>
   <td class="button-column">
     <% if can? :update, document %>
       <% if document.draft? %>
@@ -102,7 +110,7 @@
     <% end %>
   <% end %>
   </td>
-  </tr>
+</tr>
 </table>
 <script type="text/javascript">
   $(function () {

--- a/app/views/documents/_document_table.html.erb
+++ b/app/views/documents/_document_table.html.erb
@@ -9,8 +9,10 @@
     <th>
       <%= link_to "Created", documents_path( order: "created_at", docs: params[:docs], title: params[:title],author: params[:author], edition: params[:edition], anthology_id: params[:anthology_id] ) %>
     </th>
-    <th><%= ENV["CLASS_TERM_PLURAL"] %></th>
-    <th>Status</th>
+<!--    <th><%#= ENV["CLASS_TERM_PLURAL"] %></th>-->
+    <% if current_user.admin? %>
+      <th>Status</th>
+    <% end %>
     <th>Actions</th>
   </tr>
   <% documents.each do |document| %>
@@ -26,53 +28,55 @@
         <%= document.author %></td>
       <td>
         <%= document.created_at.strftime("%m/%d/%Y") %></td>
+<!--      <td>-->
+        <%# document.rep_group_list.each do |group| %>
+<!--          <span class="label label-info">-->
+<!--            <%#= group %></span>-->
+<!--        <%# end %></td>-->
+    <% if current_user.admin? %>
       <td>
-        <% document.rep_group_list.each do |group| %>
-          <span class="label label-info">
-            <%= group %></span>
-        <% end %></td>
-      <td>
-      <% if can? :update, document %>
-      <div class="btn-group" role="group" aria-label="document states">
+        <% if can? :update, document %>
+          <div class="btn-group" role="group" aria-label="document states">
 
-        <% if document.draft? %>
-          <%= link_to 'Editable', "#", :class => 'btn btn-default btn-sm active' %>
+            <% if document.draft? %>
+              <%= link_to 'Editable', "#", :class => 'btn btn-default btn-sm active' %>
+            <% else %>
+              <%= link_to 'Editable', "#", :class => 'btn btn-default btn-sm disabled' %>
+            <% end %>
+
+
+            <% if document.annotatable? %>
+              <%= link_to 'Annotatable', document_annotatable_path(document), method: :post, :class => 'btn btn-default btn-sm active' %>
+            <% else %>
+              <%= link_to 'Annotatable', document_annotatable_path(document), method: :post, :class => 'btn btn-default btn-sm' %>
+            <% end %>
+
+
+            <% if document.review? %>
+              <%= link_to 'Reviewable', document_review_path(document), method: :post, :class => 'btn btn-default btn-sm active' %>
+            <% else %>
+              <%= link_to 'Reviewable', document_review_path(document), method: :post, :class => 'btn btn-default btn-sm' %>
+            <% end %>
+
+
+            <% if document.published? %>
+              <%= link_to 'Publishable', document_publish_path(document), method: :post, :class => 'btn btn-default btn-sm active' %>
+            <% else %>
+              <%= link_to 'Publishable', document_publish_path(document), method: :post, :class => 'btn btn-default btn-sm' %>
+            <% end %>
+
+
+            <% if document.archived? %>
+              <%= link_to 'Hidden', document_archive_path(document), method: :post, :class => 'btn btn-default btn-sm active' %>
+            <% else %>
+              <%= link_to 'Hidden', document_archive_path(document), method: :post, :class => 'btn btn-default btn-sm' %>
+            <% end %>
+          </div>
         <% else %>
-          <%= link_to 'Editable', "#", :class => 'btn btn-default btn-sm disabled' %>
+          <%= document.state %>
         <% end %>
-
-
-        <% if document.annotatable? %>
-          <%= link_to 'Annotatable', document_annotatable_path(document), method: :post, :class => 'btn btn-default btn-sm active' %>
-        <% else %>
-          <%= link_to 'Annotatable', document_annotatable_path(document), method: :post, :class => 'btn btn-default btn-sm' %>
-        <% end %>
-
-
-        <% if document.review? %>
-          <%= link_to 'Reviewable', document_review_path(document), method: :post, :class => 'btn btn-default btn-sm active' %>
-        <% else %>
-          <%= link_to 'Reviewable', document_review_path(document), method: :post, :class => 'btn btn-default btn-sm' %>
-        <% end %>
-
-
-        <% if document.published? %>
-          <%= link_to 'Publishable', document_publish_path(document), method: :post, :class => 'btn btn-default btn-sm active' %>
-        <% else %>
-          <%= link_to 'Publishable', document_publish_path(document), method: :post, :class => 'btn btn-default btn-sm' %>
-        <% end %>
-
-
-        <% if document.archived? %>
-          <%= link_to 'Hidden', document_archive_path(document), method: :post, :class => 'btn btn-default btn-sm active' %>
-        <% else %>
-          <%= link_to 'Hidden', document_archive_path(document), method: :post, :class => 'btn btn-default btn-sm' %>
-        <% end %>
-      </div>
-    <% else %>
-      <%= document.state %>
+      </td>
     <% end %>
-  </td>
   <td class="button-column">
     <% if can? :update, document %>
       <% if document.draft? %>
@@ -88,17 +92,17 @@
           <%= link_to 'Edit', edit_document_path(document), :class => 'btn btn-default btn-sm', data: { toggle: 'tooltip', placement: 'top', original_title: 'Only metadata are editable' } %>
         <% end %>
       <% end %>
-      <% if controller_name == 'anthologies' && current_user.admin? %>
-        <% if document.anthologies.include?(@anthology) && current_user.admin? %>
-          <%= link_to 'Remove from anthology',
-              { action: :remove_doc, controller: 'anthologies', anthology_id: @anthology.id, document_id: document.id }, method: :post, :class => 'btn btn-danger btn-sm' %>
-        <% else %>
-          <%= link_to 'Assign to Anthology',
-            { action: :anthology_add, controller: 'documents', anthology: @anthology.id, document_ids: [document.id]}, method: :post, :class => 'btn btn-primary btn-sm' %>
-        <% end %>
+      <% if document.anthologies.include?(@anthology) && current_user.admin? %>
+        <%= link_to 'Remove from anthology',
+            { action: :remove_doc, controller: 'anthologies', anthology_id: @anthology.id, document_id: document.id }, method: :post, :class => 'btn btn-danger btn-sm' %>
+      <% else %>
+        <%= link_to 'Assign to Anthology',
+          { action: :anthology_add, controller: 'documents', anthology: @anthology.id, document_ids: [document.id]}, method: :post, :class => 'btn btn-primary btn-sm' %>
       <% end %>
     <% end %>
   <% end %>
+  </td>
+  </tr>
 </table>
 <script type="text/javascript">
   $(function () {

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -19,14 +19,14 @@
       </div>
     </div>
   <% end %>
-  <%= form_tag(documents_path, :method => "get", class: 'navbar-form navbar-left') do %>
-    <div class="input-group">
-      <%= search_field_tag :edition, params[:edition], placeholder: "Edition", class: "form-control" %>
-      <div class="input-group-btn">
-        <%= button_tag "Search", :class => 'btn btn-info',:name => nil%>
-      </div>
-    </div>
-  <% end %>
+  <%#= form_tag(documents_path, :method => "get", class: 'navbar-form navbar-left') do %>
+<!--    <div class="input-group">-->
+      <%#= search_field_tag :edition, params[:edition], placeholder: "Edition", class: "form-control" %>
+<!--      <div class="input-group-btn">-->
+        <%#= button_tag "Search", :class => 'btn btn-info',:name => nil%>
+<!--      </div>-->
+<!--    </div>-->
+  <%# end %>
 </div>
 <div class="row">
   <div class="col-md-12">

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -19,14 +19,14 @@
       </div>
     </div>
   <% end %>
-  <%#= form_tag(documents_path, :method => "get", class: 'navbar-form navbar-left') do %>
-<!--    <div class="input-group">-->
-      <%#= search_field_tag :edition, params[:edition], placeholder: "Edition", class: "form-control" %>
-<!--      <div class="input-group-btn">-->
-        <%#= button_tag "Search", :class => 'btn btn-info',:name => nil%>
-<!--      </div>-->
-<!--    </div>-->
-  <%# end %>
+  <%= form_tag(documents_path, :method => "get", class: 'navbar-form navbar-left') do %>
+    <div class="input-group">
+      <%= search_field_tag :edition, params[:edition], placeholder: "Edition", class: "form-control" %>
+      <div class="input-group-btn">
+        <%= button_tag "Search", :class => 'btn btn-info',:name => nil%>
+      </div>
+    </div>
+  <% end %>
 </div>
 <div class="row">
   <div class="col-md-12">

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -19,7 +19,7 @@
       </div>
     </div>
   <% end %>
-  <% if can? :update, @documents %>
+  <% if current_user.admin? %>
     <%= form_tag(documents_path, :method => "get", class: 'navbar-form navbar-left') do %>
       <div class="input-group">
         <%= search_field_tag :edition, params[:edition], placeholder: "Edition", class: "form-control" %>

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -19,13 +19,15 @@
       </div>
     </div>
   <% end %>
-  <%= form_tag(documents_path, :method => "get", class: 'navbar-form navbar-left') do %>
-    <div class="input-group">
-      <%= search_field_tag :edition, params[:edition], placeholder: "Edition", class: "form-control" %>
-      <div class="input-group-btn">
-        <%= button_tag "Search", :class => 'btn btn-info',:name => nil%>
+  <% if can? :update, @documents %>
+    <%= form_tag(documents_path, :method => "get", class: 'navbar-form navbar-left') do %>
+      <div class="input-group">
+        <%= search_field_tag :edition, params[:edition], placeholder: "Edition", class: "form-control" %>
+        <div class="input-group-btn">
+          <%= button_tag "Search", :class => 'btn btn-info',:name => nil%>
+        </div>
       </div>
-    </div>
+    <% end %>
   <% end %>
 </div>
 <div class="row">

--- a/config/initializers/apartment.rb
+++ b/config/initializers/apartment.rb
@@ -5,7 +5,7 @@ Apartment.configure do |config|
   # These models will not be multi-tenanted,
   # but remain in the global (public) namespace
   #
-  config.excluded_models = %w{Tenant AdminUser Delayed::Backend::ActiveRecord::Job}
+  config.excluded_models = %w{AdminUser Tenant Delayed::Backend::ActiveRecord::Job}
 
   config.use_schemas = true
 
@@ -18,11 +18,12 @@ end
 
 Rails.application.config.middleware.use 'Apartment::Elevators::Generic', lambda { |request|
   domain = request.host
-  if tenant = Tenant.where(domain: domain).first
-    tenant.database_name
-  else
-    'public'
-  end
+  # if tenant = Tenant.where(domain: domain).first
+  #   tenant.database_name
+  # else
+  #   'public'
+  # end
+  'cove-studio'
 }
 
 Rails.application.config.default_email_link_protocol = (ENV['DEFAULT_EMAIL_LINK_PROTOCOL'] || 'http')

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -217,11 +217,8 @@ Devise.setup do |config|
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
   # config.omniauth :github, 'APP_ID', 'APP_SECRET', :scope => 'user,public_repo'
-  config.omniauth :wordpress_hosted, ENV['WP_AUTH_KEY'], ENV['WP_AUTH_SECRET'],
-                  strategy_class: OmniAuth::Strategies::WordpressHosted,
-                  client_options: {
-                    site: ENV['WP_URL']
-                  }
+  config.omniauth :wordpress_hosted,
+                  :setup => true
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,9 @@ AnnotationStudio::Application.routes.draw do
   devise_for :users, controllers: {registrations: 'registrations', omniauth_callbacks: 'omniauth_callbacks'}
 
   devise_for :admin_users, ActiveAdmin::Devise.config
+  devise_scope :user do
+    match '/users/auth/wordpress_hosted/setup' => 'omniauth_callbacks#setup', via: :all, as: 'wordpress_host_setup'
+  end
   ActiveAdmin.routes(self)
 
   # catalog routes

--- a/db/migrate/20200514082011_add_config_variables_to_tenant.rb
+++ b/db/migrate/20200514082011_add_config_variables_to_tenant.rb
@@ -1,0 +1,12 @@
+class AddConfigVariablesToTenant < ActiveRecord::Migration
+  def change
+    add_column :tenants, :site_name, :string
+    add_column :tenants, :welcome_message, :string
+    add_column :tenants, :welcome_blurb, :string
+    add_column :tenants, :site_color, :string
+    add_column :tenants, :brand, :string
+    add_column :tenants, :wp_url, :string
+    add_column :tenants, :wp_auth_key, :string
+    add_column :tenants, :wp_auth_secret, :string
+  end
+end

--- a/db/migrate/20200517070324_drop_extension_pg_stat_statements.rb
+++ b/db/migrate/20200517070324_drop_extension_pg_stat_statements.rb
@@ -1,0 +1,5 @@
+class DropExtensionPgStatStatements < ActiveRecord::Migration
+  def self.up
+    disable_extension "pg_stat_statements"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200121143333) do
+ActiveRecord::Schema.define(version: 20200506054220) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -132,6 +132,7 @@ ActiveRecord::Schema.define(version: 20200121143333) do
     t.string   "cove_uri"
     t.string   "origin"
     t.boolean  "vetted"
+    t.string   "rep_group"
   end
 
   add_index "documents", ["slug"], name: "index_documents_on_slug", unique: true, using: :btree
@@ -268,6 +269,7 @@ ActiveRecord::Schema.define(version: 20200121143333) do
     t.string   "uid"
     t.integer  "cove_id"
     t.string   "full_name"
+    t.string   "rep_group"
   end
 
   add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree


### PR DESCRIPTION
## What this PR does?
1. Fixes the issues #250 #251 #252 
2. Makes it possible to order documents in anthologies manually
3. Sorting on anthology show now redirects to anthology show
4. Removes Edition tag column from the Document show view for non-admins

## How to test?
1. Login using a non admin user and go to http://cove-staging.herokuapp.com/documents
2. The Edition tag column should be present.
3. Logout
3. Login using an Admin user and go to http://cove-staging.herokuapp.com/documents
4. The Edition tag column should not be present.
5. Go to http://cove-staging.herokuapp.com/anthologies/engl-548-part-2-e-victorians (Might be some others)
6. Click on the Title, Author or Created column on the documents tab
7. It should redirect back to the anthology show and order the documents by the tab clicked(eg. title)
