### PR TITLE
Make some ui tweaks to anthologies show and edit

### DIFF
--- a/app/views/anthologies/_documents_tab.html.erb
+++ b/app/views/anthologies/_documents_tab.html.erb
@@ -17,5 +17,5 @@
             </div>
           <% end %>
         </div>
-  <p style="font-style: italic">Search to add documents to your anthology</p>
+  <p style="font-style: italic">Search to add documents to your anthology; click on All below to return to your anthology</p>
 </div>

--- a/app/views/anthologies/_form.html.erb
+++ b/app/views/anthologies/_form.html.erb
@@ -18,7 +18,7 @@
           <% end %>
           <%= f.label :banner %>
           <%= f.file_field :banner, class: 'form-control' %>
-        <i>The banner should be a png, jpg, or jpeg and should be less than 1 MB and at least 1100 # 250 pixels</i>
+        <i>The banner should be a png, jpg, or jpeg and should be less than 5 MB and at least 1100 # 250 pixels</i>
         </div>
         <div class="form-group">
           <%= f.submit nil, :class => 'btn btn-default btn btn-default-primary btn-primary' %>


### PR DESCRIPTION
## What this PR does?
1. Changed text under search to: "Search to add documents to your anthology; click on All below to return to your anthology"
2. One the edit page, change the text for the banner image field to match the new file size limit: “The banner should be a png, jpg, or jpeg and should be less than 5 MB and at least 1100 # 250 pixels”

## How to test?
1. Login to http://cove-staging.herokuapp.com/
2. Go to http://cove-staging.herokuapp.com/anthologies and pick any anthology
3. Make sure under the search part of the documents tab you can see the text: "Search to add documents to your anthology; click on All below to return to your anthology"
4. Click on edit
5. Make sure that the upload banner button has below it the text: “The banner should be a png, jpg, or jpeg and should be less than 5 MB and at least 1100 # 250 pixels”
