### PR TITLE
WIP Anthology Permissions

### DIFF
--- a/app/controllers/anthologies_controller.rb
+++ b/app/controllers/anthologies_controller.rb
@@ -2,8 +2,6 @@ class AnthologiesController < ApplicationController
   before_filter :find_anthology, :only => [:show, :edit, :destroy]
   before_filter :authenticate_user!
 
-  load_and_authorize_resource
-
   def show
     @page = 1
     if params[:page].present?

--- a/app/controllers/anthologies_controller.rb
+++ b/app/controllers/anthologies_controller.rb
@@ -15,7 +15,7 @@ class AnthologiesController < ApplicationController
     document_set = 'all'
     @tab_state = { document_set => 'active' }
     @current_tab = params[:tab]
-    if @current_tab == 'users' && current_user.admin?
+    if @current_tab == 'users' && (can? :update, Anthology)
       Rails.logger.info "******** We are in users tab"
       if !params[:docs].present? && !params[:email] && !params[:name] || params[:docs] == "all"
         @tab_state = { 'all' => 'active' }
@@ -91,7 +91,7 @@ class AnthologiesController < ApplicationController
 
           end
           if params.has_key?(:order) && params[:order].present?
-            @documents = @documents.order(params[:order]) 
+            @documents = @documents.order(params[:order])
           end
           @documents = @documents.paginate(:page => @page, :per_page =>10 )
         else

--- a/app/controllers/anthologies_controller.rb
+++ b/app/controllers/anthologies_controller.rb
@@ -2,6 +2,8 @@ class AnthologiesController < ApplicationController
   before_filter :find_anthology, :only => [:show, :edit, :destroy]
   before_filter :authenticate_user!
 
+  load_and_authorize_resource
+
   def show
     @page = 1
     if params[:page].present?

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -23,7 +23,7 @@ class Ability
       can [:read, :create], Document
       can [:read, :update, :annotatable, :review, :publish, :archive, :preview, :post_to_cove, :export, :set_default_state, :snapshot, :anthology_add], Document, { :user_id => user.id }
       can [:read], Anthology
-      can [:update, :remove_doc, :add_user, :remove_user ], Anthology, { :user_id => user.id }
+      can :manage, Anthology, { :user_id => user.id }
       can :destroy, Document, { :user_id => user.id, :published? => false }
 
     elsif user.has_role? :student
@@ -31,7 +31,7 @@ class Ability
       can [:read, :create], Document
       can [:read, :update, :anthology_add], Document, { :user_id => user.id }
       can [:read], Anthology
-      can [:update, :remove_doc, :add_user, :remove_user], Anthology, { :user_id => user.id }
+      can :manage, Anthology, { :user_id => user.id }
       can :destroy, Document, { :user_id => user.id, :published? => false }
       can :read, Document do |tors|
         !(user.rep_group_list & tors.rep_group_list).empty?

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -22,16 +22,18 @@ class Ability
       end
       can [:read, :create], Document
       can [:read, :update, :annotatable, :review, :publish, :archive, :preview, :post_to_cove, :export, :set_default_state, :snapshot, :anthology_add], Document, { :user_id => user.id }
-      can [:read], Anthology
+      cannot :manage, Anthology
       can :manage, Anthology, { :user_id => user.id }
+      can [:read], Anthology
       can :destroy, Document, { :user_id => user.id, :published? => false }
 
     elsif user.has_role? :student
       cannot :manage, Document
       can [:read, :create], Document
       can [:read, :update, :anthology_add], Document, { :user_id => user.id }
-      can [:read], Anthology
+      cannot :manage, Anthology
       can :manage, Anthology, { :user_id => user.id }
+      can [:read], Anthology
       can :destroy, Document, { :user_id => user.id, :published? => false }
       can :read, Document do |tors|
         !(user.rep_group_list & tors.rep_group_list).empty?

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -23,7 +23,7 @@ class Ability
       can [:read, :create], Document
       can [:read, :update, :annotatable, :review, :publish, :archive, :preview, :post_to_cove, :export, :set_default_state, :snapshot, :anthology_add], Document, { :user_id => user.id }
       can [:read], Anthology
-      can [:update, :remove_doc], Anthology, { :user_id => user.id }
+      can [:update, :remove_doc, :add_user, :remove_user ], Anthology, { :user_id => user.id }
       can :destroy, Document, { :user_id => user.id, :published? => false }
 
     elsif user.has_role? :student
@@ -31,7 +31,7 @@ class Ability
       can [:read, :create], Document
       can [:read, :update, :anthology_add], Document, { :user_id => user.id }
       can [:read], Anthology
-      can [:update, :remove_doc], Anthology, { :user_id => user.id }
+      can [:update, :remove_doc, :add_user, :remove_user], Anthology, { :user_id => user.id }
       can :destroy, Document, { :user_id => user.id, :published? => false }
       can :read, Document do |tors|
         !(user.rep_group_list & tors.rep_group_list).empty?

--- a/app/views/anthologies/show.html.erb
+++ b/app/views/anthologies/show.html.erb
@@ -27,7 +27,7 @@
         <% end %>
       </div>
       <div class="search-tabs-wrapper">
-        <% if can? :manage, User %>
+        <% if can? :update, Anthology %>
           <div class="container">
             <div class="media-left">
               <ul class="nav nav-tabs">

--- a/app/views/documents/_document_table.html.erb
+++ b/app/views/documents/_document_table.html.erb
@@ -108,7 +108,6 @@
                         <%= link_to 'Edit', edit_anthology_document_path(@anthology.friendly_id,document.friendly_id), :class => 'btn btn-default btn-sm', data: { toggle: 'tooltip', placement: 'top', original_title: 'Text and Metadata are editable' } %>
                     <% else %>
                         <%= link_to 'Edit', edit_document_path(document), :class => 'btn btn-default btn-sm', data: { toggle: 'tooltip', placement: 'top', original_title: 'Text and Metadata are editable' } %>
-
               <% end %>
             <% else %>
               <% if controller_name == 'anthologies' %>
@@ -129,9 +128,9 @@
               <% end %>
             <% end %>
           <% end %>
+          <% if can? :destroy, document %>
+            <%= link_to 'Delete',url_for(action: :destroy,id: document.id),method: :delete,:class => 'btn btn-danger btn-sm', data: {confirm: "Are you sure you want to delete this document permanently? All annotations on this document will also be permanently invalidated. There is no undo"} %>
           <% end %>
-          <% if current_user.admin? %>
-              <%= link_to 'Delete',url_for(action: :destroy,id: document.id),method: :delete,:class => 'btn btn-danger btn-sm', data: {confirm: "Are you sure you want to delete this document permanently? All annotations on this document will also be permanently invalidated. There is no undo"} %>
           <% end %>
         </td>
         </tr>

--- a/app/views/documents/_document_table.html.erb
+++ b/app/views/documents/_document_table.html.erb
@@ -102,15 +102,12 @@
           </td>
         <% end %>
         <td class="button-column">
-            <% if can? :update, document %>
+          <% if can? :update, document %>
                 <% if document.draft? %>
                     <% if controller_name == 'anthologies' %>
                         <%= link_to 'Edit', edit_anthology_document_path(@anthology.friendly_id,document.friendly_id), :class => 'btn btn-default btn-sm', data: { toggle: 'tooltip', placement: 'top', original_title: 'Text and Metadata are editable' } %>
                     <% else %>
                         <%= link_to 'Edit', edit_document_path(document), :class => 'btn btn-default btn-sm', data: { toggle: 'tooltip', placement: 'top', original_title: 'Text and Metadata are editable' } %>
-                        <% if current_user.admin?%>
-                            <%= link_to 'Delete',url_for(action: :destroy,id: document.id),method: :delete,:class => 'btn btn-danger btn-sm', data: {confirm: "Are you sure you want to delete this document permanently? All annotations on this document will also be permanently invalidated. There is no undo"} %>
-                        <% end %>
 
               <% end %>
             <% else %>
@@ -132,6 +129,9 @@
               <% end %>
             <% end %>
           <% end %>
+          <% end %>
+          <% if current_user.admin? %>
+              <%= link_to 'Delete',url_for(action: :destroy,id: document.id),method: :delete,:class => 'btn btn-danger btn-sm', data: {confirm: "Are you sure you want to delete this document permanently? All annotations on this document will also be permanently invalidated. There is no undo"} %>
           <% end %>
         </td>
         </tr>


### PR DESCRIPTION
See: #288 
## What this PR does?
1. Allows all users to see the list of anthologies
2. Allows all users to see the documents tab on the anthology show
3. Allows admins to edit anthologies that are not theirs 
4. Allows admins to add and remove users of anthologies that are not theirs
5. Allows all users that own anthologies to edit that anthology, add and remove users, and add and remove documents from that anthology

## How to test?
1. Login to https://staging.covecollective.org/ using your non admin account and click on Anthologies
2. You should be able to see this page without any problem.
3. Click on create new anthology and create an anthology for testing purposes.
4. Click on that anthology under the anthologies list on the dashboard
5. You should now be able to see the documents tab
6. Try to search for a user and you should be able to add and remove them
7. Try to search for a document of which you should be able to add and remove
8. You should see an edit button and be able to edit and save the anthology
9. Go back to https://staging.covecollective.org/anthologies and click on an anthology of which is not yours
10. You should be able to see the documents tab
11. You should not be able to search by documents
12. You should not see any users tab
13. You should not see an edit button
14. Login to Login to https://staging.covecollective.org/ using your admin account and click on Anthologies
15. Repeat steps 2-8
16. Repeat step 9
17. Repeat steps 4-8