### PR TITLE
Allow documents to be deleted only if we are on the documents show

### DIFF
--- a/app/views/documents/_document_table.html.erb
+++ b/app/views/documents/_document_table.html.erb
@@ -128,8 +128,10 @@
               <% end %>
             <% end %>
           <% end %>
-          <% if can? :destroy, document %>
-            <%= link_to 'Delete',url_for(action: :destroy,id: document.id),method: :delete,:class => 'btn btn-danger btn-sm', data: {confirm: "Are you sure you want to delete this document permanently? All annotations on this document will also be permanently invalidated. There is no undo"} %>
+          <% if controller_name == 'documents' %>
+            <% if can? :destroy, document %>
+              <%= link_to 'Delete',url_for(action: :destroy,id: document.id),method: :delete,:class => 'btn btn-danger btn-sm', data: {confirm: "Are you sure you want to delete this document permanently? All annotations on this document will also be permanently invalidated. There is no undo"} %>
+            <% end %>
           <% end %>
           <% end %>
         </td>


### PR DESCRIPTION
## What does this PR do?
1. Do not allow users to delete documents on the anthology show page.

## How to test?
1. Login and go to https://staging.covecollective.org/
2, Click on an anthology you own
3. Click on all tab after clicking on the documents tab.
4. There should be do delete button there
