### PR TITLE
Make the page always start at the top

### DIFF
--- a/app/views/documents/_spinner_modal.html.erb
+++ b/app/views/documents/_spinner_modal.html.erb
@@ -1,3 +1,3 @@
-<div id="spinnermodal" class="modal" tabindex="-1" role="dialog" aria-labelledby="spinnermodallabel", style=" border: 16px solid #f3f3f3; border-radius: 50%; border-top: 16px solid #000000; width: 120px; height: 120px; -webkit-animation: spin 2s linear infinite; /* Safari */ animation: spin 2s linear infinite; position: absolute; top: 45%; left: 50%; transform: translate(-45%, -50%);">
+<div id="spinnermodal" class="modal" tabindex="-1" role="dialog" aria-labelledby="spinnermodallabel", style=" border: 16px solid #f3f3f3; border-radius: 50%; border-top: 16px solid #000000; width: 120px; height: 120px; -webkit-animation: spin 2s linear infinite; /* Safari */ animation: spin 2s linear infinite; top: 45%; left: 50%; transform: translate(-45%, -50%);">
   <div class="modal-body" id="spinnerdiv"></div>
 </div>


### PR DESCRIPTION
## What does this PR do?
1. Going to a document now places the users at the top of the page instead of the middle.

## How to test?
1. Login and go to https://staging.covecollective.org/documents
2. Click on any document
3. You should be brought to the top or start of the document not the middle.