### PR TITLE
Remove the document delete button from the documents index and the an…

### DIFF
--- a/app/views/documents/_document_table.html.erb
+++ b/app/views/documents/_document_table.html.erb
@@ -128,8 +128,10 @@
               <% end %>
             <% end %>
           <% end %>
-          <% if can? :destroy, document %>
-            <%= link_to 'Delete',url_for(action: :destroy,id: document.id),method: :delete,:class => 'btn btn-danger btn-sm', data: {confirm: "Are you sure you want to delete this document permanently? All annotations on this document will also be permanently invalidated. There is no undo"} %>
+          <% if controller_name != 'anthologies' %>
+            <% if can? :destroy, document %>
+              <%= link_to 'Delete',url_for(action: :destroy,id: document.id),method: :delete,:class => 'btn btn-danger btn-sm', data: {confirm: "Are you sure you want to delete this document permanently? All annotations on this document will also be permanently invalidated. There is no undo"} %>
+            <% end %>
           <% end %>
           <% end %>
         </td>


### PR DESCRIPTION
## What does this PR do?
1. Removes delete button from documents index and anthologies index
2. Closes #292 
## How to test?
1. Login and go to https://cove-studio-issue-292-yoaxbinr.herokuapp.com/documents and see if there is a delete button on the mine tab. There should be a delete button. But there should not on the other tabs.
2. Go to https://cove-studio-issue-292-yoaxbinr.herokuapp.com/anthologies and pick an anthology
3. Now search for a document and see if when you search a document there shouldn't be any delete button.