### PR TITLE
Restored the groups widget to the dashboard

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -81,6 +81,50 @@ aria-hidden=\"true\"></span> Create new document"), document_path('new') %></li>
       </ul>
     </div><!--/ panel -->
 
+    <div class="panel panel-default" id="dashboard-groups">
+      <div class="panel-heading">
+        <span class="panel-title">
+          <%= link_to ENV["CLASS_TERM_PLURAL"], groups_path %></span>
+        <ul class="nav nav-tabs nav-tabs-xs pull-right" id="group-tabs"
+                                                        role="tablist">
+          <li>
+            <a href="#subgroups" data-toggle="tab">
+              <span class="badge"><%= current_user.rep_subgroup_list.size
+                %></span> <%= ENV["GROUP_TERM_PLURAL"] %>
+          </a>
+          </li>
+          <li class="active">
+            <a href="#groups" data-toggle="tab">
+              <span class="badge"><%= current_user.rep_group_list.size %></span>
+              <%= ENV["CLASS_TERM_PLURAL"] %>
+            </a>
+          </li>
+        </ul>
+      </div>
+      <!-- / .panel-heading -->
+
+      <div class="tab-content">
+        <div class="tab-pane no-padding fade in" id="subgroups">
+          <ul class="list-group">
+            <% current_user.rep_subgroup_list.each do |group| %>
+              <li class="list-group-item"><%= group %></li>
+            <% end %>
+          </ul>
+        </div>
+        <div class="tab-pane no-padding fade active in" id="groups">
+          <ul class="list-group">
+            <% current_user.rep_group_list.each do |group| %>
+              <li class="list-group-item"><%= link_to group, documents_path(group: group) %></li>
+            <% end %>
+          </ul>
+        </div>
+      </div>
+      <!--<ul class="nav nav-pills">-->
+      <!--<li>-->
+      <!--<%#= link_to "Go to class and group list", groups_path %>-->
+      <!--</li>-->
+      <!--</ul>-->
+    </div><!--/ panel -->
   </div><!--/ col-md-6 -->
   <div class="col-md-6">
     <div class="panel panel-default" id="dashboard-anthologies">


### PR DESCRIPTION
## What does this PR do?
1. Adds the group tags to the dashboard.
2. Closes #325 

## How to test?
1. Login to https://cove-studio-issue-325-oji1b1va.herokuapp.com/
2. Click on dashboard and make sure that you are able to see the Editions widget.
