### PR TITLE
Allow for anthology specific annotations to be downloaded

### DIFF
--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -12,7 +12,9 @@ class AnnotationsController < ApplicationController
             :user =>        current_user.email,
             :context =>     'search'
         }
-        if params[:document_id]
+        if params[:anthology_id]
+          loadOptions[:uri] = request.base_url + '/anthology/' + params[:anthology_id] +  '/documents/' + params[:document_id]
+        elsif params[:document_id]
           loadOptions[:uri] = request.base_url + '/documents/' + params[:document_id]
           Rails.logger.info "request.base_url is #{request.base_url}"
         end

--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -14,6 +14,7 @@ class AnnotationsController < ApplicationController
         }
         if params[:document_id]
           loadOptions[:uri] = request.base_url + '/documents/' + params[:document_id]
+          Rails.logger.info "request.base_url is #{request.base_url}"
         end
         @token = session['jwt']
         @loadOptions = loadOptions.to_json

--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -13,7 +13,7 @@ class AnnotationsController < ApplicationController
             :context =>     'search'
         }
         if params[:anthology_id]
-          loadOptions[:uri] = request.base_url + '/anthology/' + params[:anthology_id] +  '/documents/' + params[:document_id]
+          loadOptions[:uri] = request.base_url + '/anthologies/' + params[:anthology_id] +  '/documents/' + params[:document_id]
         elsif params[:document_id]
           loadOptions[:uri] = request.base_url + '/documents/' + params[:document_id]
           Rails.logger.info "request.base_url is #{request.base_url}"

--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -16,7 +16,6 @@ class AnnotationsController < ApplicationController
           loadOptions[:uri] = request.base_url + '/anthologies/' + params[:anthology_id] +  '/documents/' + params[:document_id]
         elsif params[:document_id]
           loadOptions[:uri] = request.base_url + '/documents/' + params[:document_id]
-          Rails.logger.info "request.base_url is #{request.base_url}"
         end
         @token = session['jwt']
         @loadOptions = loadOptions.to_json

--- a/app/views/documents/_rightnav.html.erb
+++ b/app/views/documents/_rightnav.html.erb
@@ -65,8 +65,12 @@
     <p><strong>Download HTML</strong> of the document snapshot</p>
     <%= link_to "Download HTML", document_export_path(@document), class: "btn btn-default btn-sm", role: "button" %>
     <p><strong>Download CSV</strong> of the document snapshot</p>
-    <%= link_to "Download CSV", "/documents/#{@document.slug}/annotations.csv", class: "btn btn-default btn-sm", role: "button" %>
-  <% end -%>
+    <% if params[:anthology_id].present? %>
+        <%= link_to "Download CSV", "/anthologies/#{params[:anthology_id]}/documents/#{@document.slug}/annotations.csv", class: "btn btn-default btn-sm", role: "button" %>
+    <% else %>
+        <%= link_to "Download CSV", "/documents/#{@document.slug}/annotations.csv", class: "btn btn-default btn-sm", role: "button" %>
+    <% end %>
+  <% end %>
   <h4>Switch User</h4>
   <p><strong>Remember me?</strong><%= switch_user_select class: 'form-control' %></p>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,7 +53,7 @@ AnnotationStudio::Application.routes.draw do
     get 'annotations', to: 'annotations#index'
     get 'annotations/:id', to: 'annotations#show'
     get 'documents/:document_id/annotations/field/:field', to: 'annotations#field'
-    get 'anthologies/:anthology_id/documents/:document_id/annotations/field/:field', to: 'annotations#field'
+    get 'anthologies/:anthology_id/documents/:document_id/annotations', to: 'annotations#index'
     get 'groups', to: 'groups#index'
     get 'groups/:id', to: 'groups#show'
   end


### PR DESCRIPTION
## What does this PR do?
1. Allows users to download annotations of a document created under an anthology
2. Closes #294 

## How to test?
1. Login and go to https://cove-studio-issue-294-xrevdupn.herokuapp.com/
2. Click on Dashboard
3. Click on create document
4. Create a new document and make it annotatable
5. Go back to Dashboard
6. Click on the document under mine tab and create an annotation
7. Now try to download the csv by clicking on the Download csv option on the annotation widget and see that there is row on the csv with your annotation information there
8. Go back to Dashboard
9. Create a new anthology
10. Click on that anthology under the mine tab on the Dashboard
11. Search for the document you created
12. Assign the document to that anthology
13. Click on the all tab of the anthology and click on the document you just assigned the anthology 
14. Make two new annotations and click on Download csv
15. Make sure that the csv has two records that include the annotations you just made
