### PR TITLE
Allow students and teachers to export annotations to CSV

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -39,6 +39,10 @@ class User < ActiveRecord::Base
     self.has_role?(:admin) || self == document.user
   end
 
+  def has_csv_export_permissions?
+    [:teacher, :student].any? {|role| self.has_role?(role)}
+  end
+
   def self.all_tags()
     tags = User.rep_group_counts.map{|t| t.name}
     return tags.sort!

--- a/app/views/documents/_rightnav.html.erb
+++ b/app/views/documents/_rightnav.html.erb
@@ -64,6 +64,8 @@
     <%= link_to "Preview", document_preview_path(@document), class: "btn btn-default btn-sm", role: "button" %>
     <p><strong>Download HTML</strong> of the document snapshot</p>
     <%= link_to "Download HTML", document_export_path(@document), class: "btn btn-default btn-sm", role: "button" %>
+  <% end %>
+  <% if @document.present? && current_user.has_document_permissions?(@document) || current_user.has_csv_export_permissions? %>
     <p><strong>Download CSV</strong> of the document snapshot</p>
     <% if params[:anthology_id].present? %>
         <%= link_to "Download CSV", "/anthologies/#{params[:anthology_id]}/documents/#{@document.slug}/annotations.csv", class: "btn btn-default btn-sm", role: "button" %>


### PR DESCRIPTION
- Display 'Download CSV' button on Annotations sidebar for teachers and students (in addition to admins) 
  
![Screen Shot 2021-01-25 at 1 14 35 AM](https://user-images.githubusercontent.com/20568337/105673104-29e19400-5eab-11eb-9de7-423d016265e0.png)
