### PR TITLE
Change Document publication_date column type from :date to :string

### DIFF
--- a/db/migrate/20210303031516_change_document_publication_date.rb
+++ b/db/migrate/20210303031516_change_document_publication_date.rb
@@ -1,0 +1,5 @@
+class ChangeDocumentPublicationDate < ActiveRecord::Migration
+  def change
+    change_column :documents, :publication_date, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -117,7 +117,7 @@ ActiveRecord::Schema.define(version: 20200903142800) do
     t.string   "rights_status",       limit: 255
     t.string   "slug",                limit: 255
     t.integer  "user_id"
-    t.date     "publication_date"
+    t.string   "publication_date"
     t.text     "chapters"
     t.string   "state",               limit: 255
     t.string   "upload_file_name",    limit: 255


### PR DESCRIPTION
**What this PR does:**

- Change `publication_date` field for `Document` records from `date` to `string`
- **Existing `date` data will be converted to `string` in 'YYYY-MM-DD' format; no change needed for existing data**

**Steps to test:**

1. Navigate to Documents index (/documents) and click on 'Edit' button for any given document
2. Update 'Publication field' date to anything (i.e. "Early 1800s", "1826-04-23", "Victorian Era", "1826", etc.) and save changes
3. Navigate away and back to same Document record - observe that updated 'Publication field' value persists

**Visual change(s):**
N/A