### PR TITLE
Update help text on Group tags field of Documents form

### DIFF
--- a/app/views/documents/_form.html.erb
+++ b/app/views/documents/_form.html.erb
@@ -91,7 +91,8 @@
 
 			  <div class="col-md-6">
           	<h4><%= ENV["CLASS_TERM_PLURAL"] %></h4>
-          	<p class="help-block">Enter the <%= ENV["CLASS_TERM_PLURAL"] %> to which you wish to assign this document, <strong>and press enter after each.</strong></p>
+          	<p class="help-block">If you are using the anthology-builder (preferred method), go to your anthology and add this document to your anthology from that interface.</p>
+          	<p class="help-block">If you are using <%= ENV["CLASS_TERM_PLURAL"] %>, enter the <%= ENV["CLASS_TERM_PLURAL"] %> to which you wish to assign this document, <strong>and press enter after each.</strong></p>
           	<div class="form-group">
           	<%= f.text_field :rep_group_list, :value => @document.rep_group_list.join(', '), :class => 'form-control', 'data-role' => "tagsinput", 'placeholder' => ENV["CLASS_TERM_PLURAL"] %>
           	</div>


### PR DESCRIPTION
**What this PR does:**

- Update help text on Group tags field of Documents form

**Steps to test:**

1. Navigate to new/edit Document form (/documents/new)
2. Observe presence of helper text as specified in linked issue #332 (note - "Group" will differ based on `CLASS_TERM_PLURAL` variable, e.g. "Editions"

**Visual change(s):**
<img width="1174" alt="Screen Shot 2021-03-02 at 10 20 45 PM" src="https://user-images.githubusercontent.com/20568337/109756384-76587780-7bad-11eb-8ed7-d83df452cf2e.png">
