### PR TITLE
Add conditional render for 'Content' block ONLY for editable or new docs

### DIFF
--- a/app/views/documents/_form.html.erb
+++ b/app/views/documents/_form.html.erb
@@ -1,5 +1,8 @@
           <%= form_for (@document), :html => { :role => 'form', class: "confirm-changes" } do |f| %>
-<%= render 'document_content', f: f %>
+
+            <% if [nil, "draft"].any? {|state| state == @document.state} %>
+              <%= render 'document_content', f: f %>
+            <% end %>
 
           	<h4>Metadata</h4>
 


### PR DESCRIPTION
**What this PR does:**

- Adds conditional rendering on Document form to only show 'Content' block for editable documents (or new documents, which don't yet have a state)


**Steps to test:**

1. Navigate to the new Document form (/documents/new) (or edit form for an existing editable document) and observe that the 'Content' block is visible above the 'Metadata' block
2. Navigate to the edit Document form for an existing document that is NOT in editable state, and observe that the 'Content' block is NOT visible above the 'Metadata' block

**Visual change(s):**
New (editable) document:
<img width="802" alt="Screen Shot 2021-03-02 at 11 36 13 PM" src="https://user-images.githubusercontent.com/20568337/109758503-4ca14f80-7bb1-11eb-99fa-de24c255a82f.png">

Annotatable (i.e. not editable) document:
<img width="945" alt="Screen Shot 2021-03-02 at 11 35 51 PM" src="https://user-images.githubusercontent.com/20568337/109758544-5b880200-7bb1-11eb-8da6-8ff8af994864.png">
