### PR TITLE
Add helper text and disable 'Preview' button if no document snapshot

### DIFF
--- a/app/views/documents/_rightnav.html.erb
+++ b/app/views/documents/_rightnav.html.erb
@@ -60,8 +60,8 @@
     <p><strong>Save</strong> document for export</p>
     <a id="snapshot_trigger" class="btn btn-default btn-sm" href="#" role="button">Save Document</a>
 
-    <p><strong>Preview</strong> of the document snapshot</p>
-    <%= link_to "Preview", document_preview_path(@document), class: "btn btn-default btn-sm", role: "button" %>
+    <p><strong>Preview</strong> of the document snapshot <i>(requires saved snapshot)</i> </p>
+    <%= link_to "Preview", document_preview_path(@document), class: "btn btn-default btn-sm", role: "button", disabled: !@document.snapshot %>
     <p><strong>Download HTML</strong> of the document snapshot</p>
     <%= link_to "Download HTML", document_export_path(@document), class: "btn btn-default btn-sm", role: "button" %>
   <% end %>


### PR DESCRIPTION
**What this PR does:**

- Add helper text and disable 'Preview' button if no document snapshot


**Steps to test:**

1. Navigate to a document which does not have a saved snapshot; observe that the 'Preview' button on the right sidebar is disabled
2. Save a snapshot ('Save Document' button)
3. Refresh page; observe that the 'Preview' button is now enabled

**Visual change(s):**
<img width="802" alt="Screen Shot 2021-03-05 at 1 00 23 AM" src="https://user-images.githubusercontent.com/20568337/110082834-81e5a300-7d53-11eb-8f6d-e3ea3e851e05.png">
