### PR TITLE
Add per-tenant banner color selection through ActiveAdmin

### DIFF
--- a/app/admin/tenants.rb
+++ b/app/admin/tenants.rb
@@ -1,7 +1,7 @@
 ActiveAdmin.register Tenant do
   permit_params :domain, :database_name, :mel_catalog_enabled, :mel_catalog_url, :annotation_categories_enabled,
                 :site_name, :welcome_message, :welcome_blurb, :site_color, :brand, :wp_url, :wp_auth_key,
-                :wp_auth_secret, :idp_sso_target_url, :idp_cert_fingerprint, :google_analytics_code, auth_allowed: []
+                :wp_auth_secret, :idp_sso_target_url, :idp_cert_fingerprint, :google_analytics_code, :banner_color, auth_allowed: []
 
   scope :all, :default => true
 
@@ -42,7 +42,8 @@ ActiveAdmin.register Tenant do
       f.input :site_name, :as => :string, label: 'Enter Site name:'
       f.input :welcome_message, :as => :string, label: 'Welcome message for this tenant:'
       f.input :welcome_blurb, :as => :string, label: 'Welcome blurb for this tenant:'
-      f.input :site_color, :as => :color, label: 'Customize a site color(Hex Code):'
+      f.input :site_color, :as => :color, label: 'Customize a site color (Hex Code):'
+      f.input :banner_color, :as => :color, label: 'Customize a banner background color (Hex Code):'
       f.input :brand, :as => :string, label: 'Enter the brand'
       f.input :wp_url, :as => :string, label: 'Enter WordPress hosted Url'
       f.input :wp_auth_key, :as => :string, label: 'Enter WordPress Auth Key'

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,4 +1,6 @@
-<% google_analytics_code = Tenant.find_by(database_name: Apartment::Tenant.current_tenant)&.google_analytics_code || ENV["GOOGLE_ANALYTICS_CODE"] %>
+<% tenant = Tenant.find_by(database_name: Apartment::Tenant.current_tenant) %>
+<% google_analytics_code = tenant&.google_analytics_code || ENV["GOOGLE_ANALYTICS_CODE"] %>
+<% banner_color = tenant&.banner_color || '#000' %>
 
 <!DOCTYPE html>
 <html lang="en">
@@ -40,7 +42,7 @@
 </head>
 <body id="<%= yield(:body_id) %>" class="<%= yield(:body_class) %>">
 
-    <nav class="navbar navbar-inverse navbar-fixed-top" id="navbar">
+    <nav class="navbar navbar-inverse navbar-fixed-top" id="navbar" style="background-color: <%= banner_color %>;">
       <div class="container">
         <%= render "#{ $DOMAIN_CONFIG['brand'] }" %>
       </div>

--- a/db/migrate/20211207234932_add_banner_color_to_tenant.rb
+++ b/db/migrate/20211207234932_add_banner_color_to_tenant.rb
@@ -1,0 +1,5 @@
+class AddBannerColorToTenant < ActiveRecord::Migration
+  def change
+    add_column :tenants, :banner_color, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210816051651) do
+ActiveRecord::Schema.define(version: 20211207234932) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -248,6 +248,7 @@ ActiveRecord::Schema.define(version: 20210816051651) do
     t.string   "idp_sso_target_url"
     t.string   "idp_cert_fingerprint"
     t.string   "google_analytics_code"
+    t.string   "banner_color"
   end
 
   add_index "tenants", ["database_name"], name: "index_tenants_on_database_name", using: :btree


### PR DESCRIPTION
- Make banner color configurable per client
- Default to black if no banner color chosen
- Banner color can be configured through ActiveAdmin dashboard  
<img width="807" alt="Screen Shot 2021-12-07 at 8 48 32 PM" src="https://user-images.githubusercontent.com/20568337/145140775-86d9968b-1251-48e2-bc20-a66e1051c6d9.png">  

<img width="1438" alt="Screen Shot 2021-12-07 at 8 49 30 PM" src="https://user-images.githubusercontent.com/20568337/145140810-8a73bc4c-55ef-4c58-9c9f-ceb68da8a043.png">


