### PR TITLE
Shorten penn state and coastal site_names

### DIFF
--- a/config/domain_specific/config.yml
+++ b/config/domain_specific/config.yml
@@ -306,7 +306,7 @@ macerata.covecollective.org:
     firstname: 'urn:oid:2.5.4.42'
     lastname: 'urn:oid:2.5.4.4'
 coastal-staging.covecollective.org:
-  site_name: Coastal Carolina University - Staging
+  site_name: Coastal Carolina - Staging
   welcome_message: 'Welcome to COVE Studio for Coastal Carolina University'
   welcome_blurb: 'Welcome to COVE Studio for Coastal Carolina University'
   site_color: '#006F71'
@@ -318,7 +318,7 @@ coastal-staging.covecollective.org:
     firstname: 'urn:oid:2.5.4.42'
     lastname: 'urn:oid:2.5.4.4'
 coastal.covecollective.org:
-  site_name: Coastal Carolina University
+  site_name: Coastal Carolina
   welcome_message: 'Welcome to COVE Studio for Coastal Carolina University'
   welcome_blurb: 'Welcome to COVE Studio for Coastal Carolina University'
   site_color: '#006F71'
@@ -330,7 +330,7 @@ coastal.covecollective.org:
     firstname: 'urn:oid:2.5.4.42'
     lastname: 'urn:oid:2.5.4.4'
 psu-staging.covecollective.org:
-  site_name: Penn State University - Staging
+  site_name: Penn State - Staging
   welcome_message: 'Welcome to COVE Studio for Penn State'
   welcome_blurb: 'Welcome to COVE Studio for Penn State'
   site_color: '#ffffff'
@@ -342,7 +342,7 @@ psu-staging.covecollective.org:
     firstname: 'urn:oid:2.5.4.42'
     lastname: 'urn:oid:2.5.4.4'
 psu.covecollective.org:
-  site_name: Penn State University
+  site_name: Penn State
   welcome_message: 'Welcome to COVE Studio for Penn State'
   welcome_blurb: 'Welcome to COVE Studio for Penn State'
   site_color: '#ffffff'


### PR DESCRIPTION
# What this PR does

This PR removes "University" from the `site_name` config field for both Penn State and Coastal Carolina. This is a quick partial fix to alleviate #394 that Dino requested while we work on the navbar redesign.

Old:
![Screen Shot 2022-03-18 at 10 37 04 AM](https://user-images.githubusercontent.com/64725469/159023194-4f48d727-5022-4a09-aabe-772dc7116e04.png)

New:
![Screen Shot 2022-03-18 at 10 37 17 AM](https://user-images.githubusercontent.com/64725469/159023209-8ab2111d-62d0-4372-8ff0-703a368cb392.png)
