### PR TITLE
Add SAML provider config for new tenants

### DIFF
--- a/config/domain_specific/config.yml
+++ b/config/domain_specific/config.yml
@@ -288,6 +288,7 @@ macerata-staging.covecollective.org:
   site_color: '#957375'
   home_banner: 'macerata_banner.png'
   brand: 'shared/macerata_brand.html.erb'
+  saml_provider: 'unimc.it'
   saml_metadata: '/saml/macerata_metadata.xml'
   saml_attributes:
     email: 'urn:oid:0.9.2342.19200300.100.1.3'
@@ -300,6 +301,7 @@ macerata.covecollective.org:
   site_color: '#957375'
   home_banner: 'macerata_banner.png'
   brand: 'shared/macerata_brand.html.erb'
+  saml_provider: 'unimc.it'
   saml_metadata: '/saml/macerata_metadata.xml'
   saml_attributes:
     email: 'urn:oid:0.9.2342.19200300.100.1.3'
@@ -312,6 +314,7 @@ coastal-staging.covecollective.org:
   site_color: '#006F71'
   home_banner: 'coastal_banner.jpg'
   brand: 'shared/coastal_brand'
+  saml_provider: 'coastal.edu'
   saml_metadata: '/saml/coastal_metadata.xml'
   saml_attributes:
     email: 'urn:oid:0.9.2342.19200300.100.1.3'
@@ -324,6 +327,7 @@ coastal.covecollective.org:
   site_color: '#006F71'
   home_banner: 'coastal_banner.jpg'
   brand: 'shared/coastal_brand'
+  saml_provider: 'coastal.edu'
   saml_metadata: '/saml/coastal_metadata.xml'
   saml_attributes:
     email: 'urn:oid:0.9.2342.19200300.100.1.3'
@@ -336,6 +340,7 @@ psu-staging.covecollective.org:
   site_color: '#ffffff'
   home_banner: 'psu_banner.png'
   brand: 'shared/psu_brand'
+  saml_provider: 'psu.edu'
   saml_metadata: '/saml/psu_metadata.xml'
   saml_attributes:
     email: 'urn:oid:0.9.2342.19200300.100.1.3'
@@ -348,6 +353,7 @@ psu.covecollective.org:
   site_color: '#ffffff'
   home_banner: 'psu_banner.png'
   brand: 'shared/psu_brand'
+  saml_provider: 'psu.edu'
   saml_metadata: '/saml/psu_metadata.xml'
   saml_attributes:
     email: 'urn:oid:0.9.2342.19200300.100.1.3'


### PR DESCRIPTION
# What this PR does

This PR adds a `saml_provider` field for each of the new tenants, linking to each tenant's website.

For example, Penn State's line is `saml_provider: 'psu.edu'`

This should fix the authentication issues reported by the Coastal Carolina technical staff.