### PR TITLE
Fix entity IDs for new tenants

### DIFF
--- a/app/views/saml/coastal_metadata.xml
+++ b/app/views/saml/coastal_metadata.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" entityID="https://coastal.covecollective.org/sp/metadata" ID="COVE Studio Staging">
+<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" entityID="https://coastal.covecollective.org/sp/metadata" ID="COVE Studio">
   <SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
     <KeyDescriptor use="signing">
       <ds:KeyInfo>

--- a/app/views/saml/macerata_staging_metadata.xml
+++ b/app/views/saml/macerata_staging_metadata.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" entityID="https://macerata-staging.covecollective.org/sp/metadata" ID="COVE Studio">
+<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" entityID="https://macerata-staging.covecollective.org/sp/metadata" ID="COVE Studio Staging">
   <SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
     <KeyDescriptor use="signing">
       <ds:KeyInfo>

--- a/app/views/saml/psu_metadata.xml
+++ b/app/views/saml/psu_metadata.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" entityID="https://psu.covecollective.org/sp/metadata" ID="COVE Studio Staging">
+<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" entityID="https://psu.covecollective.org/sp/metadata" ID="COVE Studio">
   <SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
     <KeyDescriptor use="signing">
       <ds:KeyInfo>


### PR DESCRIPTION
# What this PR does

This PR fixes incorrect `ID` attributes on the following tenants:
* Coastal
* Macerata Staging
* PSU

These metadata files had the opposite values they should have had regarding whether they are staging or production.