### PR TITLE
Fix AVSA link

### DIFF
--- a/app/views/shared/_alabama_brand.html.erb
+++ b/app/views/shared/_alabama_brand.html.erb
@@ -44,7 +44,7 @@
 				</li>
 				<li class="header-logo divider"> | </li>
 				<li class="header-logo">
-					<%= link_to("AVSA", "http://www.avsa.unimelb.edu.au/") %>
+					<%= link_to("AVSA", "https://avsa.net.au/") %>
 				</li>
 				<li class="header-logo divider"> | </li>
 				<li class="header-logo">

--- a/app/views/shared/_bavs_brand.html.erb
+++ b/app/views/shared/_bavs_brand.html.erb
@@ -43,7 +43,7 @@
 				</li>
 				<li class="header-logo divider"> | </li>
 				<li class="header-logo">
-					<%= link_to("AVSA", "http://www.avsa.unimelb.edu.au/") %>
+					<%= link_to("AVSA", "https://avsa.net.au/") %>
 				</li>
 				<li class="header-logo divider"> | </li>
 				<li class="header-logo">

--- a/app/views/shared/_chicago_brand.html.erb
+++ b/app/views/shared/_chicago_brand.html.erb
@@ -44,7 +44,7 @@
 				</li>
 				<li class="header-logo divider"> | </li>
 				<li class="header-logo">
-					<%= link_to("AVSA", "http://www.avsa.unimelb.edu.au/") %>
+					<%= link_to("AVSA", "https://avsa.net.au/") %>
 				</li>
 				<li class="header-logo divider"> | </li>
 				<li class="header-logo">

--- a/app/views/shared/_coastal_brand.html.erb
+++ b/app/views/shared/_coastal_brand.html.erb
@@ -44,7 +44,7 @@
 				</li>
 				<li class="header-logo divider"> | </li>
 				<li class="header-logo">
-					<%= link_to("AVSA", "http://www.avsa.unimelb.edu.au/") %>
+					<%= link_to("AVSA", "https://avsa.net.au/") %>
 				</li>
 				<li class="header-logo divider"> | </li>
 				<li class="header-logo">

--- a/app/views/shared/_columbia_college_brand.html.erb
+++ b/app/views/shared/_columbia_college_brand.html.erb
@@ -44,7 +44,7 @@
 				</li>
 				<li class="header-logo divider"> | </li>
 				<li class="header-logo">
-					<%= link_to("AVSA", "http://www.avsa.unimelb.edu.au/") %>
+					<%= link_to("AVSA", "https://avsa.net.au/") %>
 				</li>
 				<li class="header-logo divider"> | </li>
 				<li class="header-logo">

--- a/app/views/shared/_cove_brand.html.erb
+++ b/app/views/shared/_cove_brand.html.erb
@@ -44,7 +44,7 @@
 				</li>
 				<li class="header-logo divider"> | </li>
 				<li class="header-logo">
-					<%= link_to("AVSA", "http://www.avsa.unimelb.edu.au/") %>
+					<%= link_to("AVSA", "https://avsa.net.au/") %>
 				</li>
 				<li class="header-logo divider"> | </li>
 				<li class="header-logo">

--- a/app/views/shared/_macerata_brand.html.erb
+++ b/app/views/shared/_macerata_brand.html.erb
@@ -44,7 +44,7 @@
 				</li>
 				<li class="header-logo divider"> | </li>
 				<li class="header-logo">
-					<%= link_to("AVSA", "http://www.avsa.unimelb.edu.au/") %>
+					<%= link_to("AVSA", "https://avsa.net.au/") %>
 				</li>
 				<li class="header-logo divider"> | </li>
 				<li class="header-logo">

--- a/app/views/shared/_nassr_brand.html.erb
+++ b/app/views/shared/_nassr_brand.html.erb
@@ -44,7 +44,7 @@
 				</li>
 				<li class="header-logo divider"> | </li>
 				<li class="header-logo">
-					<%= link_to("AVSA", "http://www.avsa.unimelb.edu.au/") %>
+					<%= link_to("AVSA", "https://avsa.net.au/") %>
 				</li>
 				<li class="header-logo divider"> | </li>
 				<li class="header-logo">

--- a/app/views/shared/_navsa_conference_brand.html.erb
+++ b/app/views/shared/_navsa_conference_brand.html.erb
@@ -34,7 +34,7 @@
 				</li>
 				<li class="header-logo divider"> | </li>
 				<li class="header-logo">
-					<%= link_to("AVSA", "http://www.avsa.unimelb.edu.au/") %>
+					<%= link_to("AVSA", "https://avsa.net.au/") %>
 				</li>
 				<li class="header-logo divider"> | </li>
 				<li class="header-logo">

--- a/app/views/shared/_odu_brand.html.erb
+++ b/app/views/shared/_odu_brand.html.erb
@@ -44,7 +44,7 @@
 				</li>
 				<li class="header-logo divider"> | </li>
 				<li class="header-logo">
-					<%= link_to("AVSA", "http://www.avsa.unimelb.edu.au/") %>
+					<%= link_to("AVSA", "https://avsa.net.au/") %>
 				</li>
 				<li class="header-logo divider"> | </li>
 				<li class="header-logo">

--- a/app/views/shared/_princeton_brand.html.erb
+++ b/app/views/shared/_princeton_brand.html.erb
@@ -44,7 +44,7 @@
 				</li>
 				<li class="header-logo divider"> | </li>
 				<li class="header-logo">
-					<%= link_to("AVSA", "http://www.avsa.unimelb.edu.au/") %>
+					<%= link_to("AVSA", "https://avsa.net.au/") %>
 				</li>
 				<li class="header-logo divider"> | </li>
 				<li class="header-logo">

--- a/app/views/shared/_psu_brand.html.erb
+++ b/app/views/shared/_psu_brand.html.erb
@@ -44,7 +44,7 @@
 				</li>
 				<li class="header-logo divider"> | </li>
 				<li class="header-logo">
-					<%= link_to("AVSA", "http://www.avsa.unimelb.edu.au/") %>
+					<%= link_to("AVSA", "https://avsa.net.au/") %>
 				</li>
 				<li class="header-logo divider"> | </li>
 				<li class="header-logo">

--- a/app/views/shared/_purdue_brand.html.erb
+++ b/app/views/shared/_purdue_brand.html.erb
@@ -44,7 +44,7 @@
 				</li>
 				<li class="header-logo divider"> | </li>
 				<li class="header-logo">
-					<%= link_to("AVSA", "http://www.avsa.unimelb.edu.au/") %>
+					<%= link_to("AVSA", "https://avsa.net.au/") %>
 				</li>
 				<li class="header-logo divider"> | </li>
 				<li class="header-logo">

--- a/app/views/shared/_ryerson_brand.html.erb
+++ b/app/views/shared/_ryerson_brand.html.erb
@@ -44,7 +44,7 @@
 				</li>
 				<li class="header-logo divider"> | </li>
 				<li class="header-logo">
-					<%= link_to("AVSA", "http://www.avsa.unimelb.edu.au/") %>
+					<%= link_to("AVSA", "https://avsa.net.au/") %>
 				</li>
 				<li class="header-logo divider"> | </li>
 				<li class="header-logo">

--- a/app/views/shared/_unl_brand.html.erb
+++ b/app/views/shared/_unl_brand.html.erb
@@ -44,7 +44,7 @@
 				</li>
 				<li class="header-logo divider"> | </li>
 				<li class="header-logo">
-					<%= link_to("AVSA", "http://www.avsa.unimelb.edu.au/") %>
+					<%= link_to("AVSA", "https://avsa.net.au/") %>
 				</li>
 				<li class="header-logo divider"> | </li>
 				<li class="header-logo">


### PR DESCRIPTION
# What this PR does

This PR fixes the AVSA link in the navbar so it leads to their new URL, https://avsa.net.au.

Previously, it led to http://www.avsa.unimelb.edu.au, which is no longer active.