### PR TITLE
Use HTTPS instead of git protocol for `omniauth-wordpress_hosted`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem 'apartment', '1.2.0'
 gem 'net-ssh'
 gem 'select2-rails', '< 4.0'
 gem 'omniauth-oauth2', '1.3.1'
-gem 'omniauth-wordpress_hosted', github: 'jwickard/omniauth-wordpress-oauth2-plugin'
+gem 'omniauth-wordpress_hosted', git: 'https://github.com/jwickard/omniauth-wordpress-oauth2-plugin'
 gem 'omniauth-saml'
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: https://github.com/jwickard/omniauth-wordpress-oauth2-plugin.git
+  remote: https://github.com/jwickard/omniauth-wordpress-oauth2-plugin
   revision: 0e522573a7cc91fad85b091f63015abf8f8a4028
   specs:
     omniauth-wordpress_hosted (0.0.5)


### PR DESCRIPTION
# What this PR does

For some reason, my bundler fetched the `omniauth-wordpress_hosted` gem over HTTPS and updated the lockfile accordingly, while Heroku tried to fetch it via `git://`, breaking the build. This PR updates the Gemfile to explicitly use HTTPS, which should make builds identical between my computer and Heroku.