### PR TITLE
Redirect properly when batch adding documents

### DIFF
--- a/app/controllers/anthologies_controller.rb
+++ b/app/controllers/anthologies_controller.rb
@@ -120,27 +120,6 @@ class AnthologiesController < ApplicationController
 
   end
 
-  def remove_doc
-    respond_to do |format|
-      @anthology = Anthology.find(params[:anthology_id])
-      Rails.logger.info "**** entering remove doc"
-      @document = Document.find(params[:document_id])
-      Rails.logger.info "The doc is #{@document.inspect}"
-
-      if @anthology.present? && @document.present? && @anthology.documents.delete(@document)
-        @document.rep_group_list.remove(@anthology.slug)
-        @document.save
-        if params[:tab_state]['search_results']
-          format.html { redirect_to anthology_path(@anthology, title: params[:title], author: params[:author], page: params[:page], docs: 'search_results'), notice: "The document #{@document.title } was successfully removed from this anthology"}
-        else
-          format.html { redirect_to anthology_path(@anthology, title: params[:title], author: params[:author], docs: 'all'), notice: "The document #{@document.title } was successfully removed from this anthology"}
-        end
-      else
-        format.html { redirect_to anthologies_path, error: "There was a problem removing the document from this anthology" }
-      end
-    end
-  end
-
   def remove_user
     respond_to do |format|
       @anthology = Anthology.find(params[:anthology_id])

--- a/app/views/documents/_document_table.html.erb
+++ b/app/views/documents/_document_table.html.erb
@@ -2,12 +2,20 @@
   <% if controller_name == 'anthologies' %>
     <% if current_user.admin? || @anthology.user == current_user %>
       <div class="doc-table-flex-row">
-        <%= submit_tag "Add selected", :class => 'btn btn-primary btn-sm add-selected-documents-btn' %>
+        <% if tab_state['search_results'] %>
+          <%= hidden_field_tag 'page', params[:page] %>
+          <%= hidden_field_tag 'title', params[:title] %>
+          <%= hidden_field_tag 'author', params[:author] %>
+          <%= hidden_field_tag 'docs', params[:docs] %>
+          <%= submit_tag "Add selected", :class => 'btn btn-primary btn-sm add-selected-documents-btn' %>
+        <% end %>
       </div>
     <% end %>
   <% end %>
   <tr>
-    <th>Select</th>
+    <% if tab_state['search_results'] %>
+      <th>Select</th>
+    <% end %>
     <th>
       <% if %w[documents].include?(controller_name) %>
         <%= link_to "Title", documents_path( order: "title", docs: params[:docs], title: params[:title],author: params[:author], edition: params[:edition], anthology_id: params[:anthology_id] ) %>
@@ -42,9 +50,11 @@
   </tr>
   <% documents.each do |document| %>
     <tr>
-      <td class="button-column">
-        <%= check_box_tag 'document_ids[]', document.id, false, :class => 'document-checkbox' %>
-      </td>
+      <% if tab_state['search_results'] %>
+        <td class="button-column">
+          <%= check_box_tag 'document_ids[]', document.id, false, :class => 'document-checkbox' %>
+        </td>
+      <% end %>
       <td>
         <% if controller_name == 'anthologies' %>
           <%= link_to document.title, anthology_document_path(@anthology.friendly_id, document.friendly_id) %></td>
@@ -136,10 +146,10 @@
             <% if current_user.admin? || @anthology.user == current_user %>
               <% if document.anthologies.include?(@anthology)  %>
                 <%= link_to 'Remove from anthology',
-                            { action: :remove_doc, controller: 'anthologies', anthology_id: @anthology.id, document_id: document.id, title: params[:title], author: params[:author], page: params[:page], tab_state: tab_state }, method: :post, :class => 'btn btn-danger btn-sm' %>
+                  { action: :anthology_remove, controller: 'documents', anthology: @anthology.id, document_ids: [document.id], title: params[:title], author: params[:author], page: params[:page], tab_state: tab_state}, method: :post, :class => 'btn btn-danger btn-sm' %>
               <% else %>
                 <%= link_to 'Assign to Anthology',
-                            { action: :anthology_add, controller: 'documents', anthology: @anthology.id, document_ids: [document.id], title: params[:title], author: params[:author], page: params[:page]}, method: :post, :class => 'btn btn-primary btn-sm' %>
+                  { action: :anthology_add, controller: 'documents', anthology: @anthology.id, document_ids: [document.id], title: params[:title], author: params[:author], page: params[:page], tab_state: tab_state}, method: :post, :class => 'btn btn-primary btn-sm' %>
               <% end %>
             <% end %>
           <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,9 +26,9 @@ AnnotationStudio::Application.routes.draw do
   get 'documents/catalog/image/:eid', to: 'catalog#image'
   get 'documents/catalog/reference/:eid', to: 'catalog#reference'
   post 'anthology_add', to: 'documents#anthology_add'
+  post 'anthology_remove', to: 'documents#anthology_remove'
   post 'user_anthology_add', to: 'users#anthology_add'
   post 'remove_user', to: 'users#remove_user'
-  post 'remove_doc', to: 'anthologies#remove_doc'
   post 'remove_anthology_user', to: 'anthologies#remove_user'
   post 'add_anthology_user', to: "anthologies#add_user"
 


### PR DESCRIPTION
# What this PR does

This PR extends the redirect feature from #418 to also support the batch addition method from #417.

This PR also includes some refactoring to make document removal work the same way as document addition, hopefully making it easier to add a batch remove button in the near future.