### PR TITLE
Add batch remove and select all buttons to anthology page

### DIFF
--- a/app/assets/stylesheets/anthologies.scss
+++ b/app/assets/stylesheets/anthologies.scss
@@ -47,9 +47,13 @@
 .doc-table-flex-row {
   width: 100%;
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
   gap: 10px;
   padding: 10px;
+}
+
+#document-form-select-all {
+  justify-self: flex-start;
 }
 
 .document-checkbox {

--- a/app/views/anthologies/_searched_documents.erb
+++ b/app/views/anthologies/_searched_documents.erb
@@ -24,8 +24,14 @@
         <div class="tab-content">
           <div class="tab-pane no-padding active" id="all">
             <% unless documents.blank? %>
-              <%= form_tag(anthology_add_path(anthology: anthology.id), :method => "post") do %>
-                <%= render partial: 'documents/document_table', locals: { documents: documents, tab_state: tab_state } %>
+              <% if tab_state['search_results'] %>
+                <%= form_tag(anthology_add_path(anthology: anthology.id), :method => "post") do %>
+                  <%= render partial: 'documents/document_table', locals: { documents: documents, tab_state: tab_state } %>
+                <% end %>
+              <% elsif tab_state['all'] %>
+                <%= form_tag(anthology_remove_path(anthology: anthology.id), :method => "post") do %>
+                  <%= render partial: 'documents/document_table', locals: { documents: documents, tab_state: tab_state } %>
+                <% end %>
               <% end %>
             <% else %>
               <div class="container">

--- a/app/views/documents/_document_table.html.erb
+++ b/app/views/documents/_document_table.html.erb
@@ -2,18 +2,25 @@
   <% if controller_name == 'anthologies' %>
     <% if current_user.admin? || @anthology.user == current_user %>
       <div class="doc-table-flex-row">
+        <%= hidden_field_tag 'page', params[:page] %>
+        <%= hidden_field_tag 'title', params[:title] %>
+        <%= hidden_field_tag 'author', params[:author] %>
+        <%= hidden_field_tag 'docs', params[:docs] %>
+        <%= hidden_field_tag 'tab_state', params[:tab_state] %>
+        <div>
+          <button id='document-form-select-all' class='btn btn-primary btn-sm' type='button' onClick='selectAll()'>Select All</button>
+          <button id='document-form-select-all' class='btn btn-warning btn-sm' type='button' onClick='deselectAll()'>Deselect All</button>
+        </div>
         <% if tab_state['search_results'] %>
-          <%= hidden_field_tag 'page', params[:page] %>
-          <%= hidden_field_tag 'title', params[:title] %>
-          <%= hidden_field_tag 'author', params[:author] %>
-          <%= hidden_field_tag 'docs', params[:docs] %>
           <%= submit_tag "Add selected", :class => 'btn btn-primary btn-sm add-selected-documents-btn' %>
+        <% elsif tab_state['all'] %>
+          <%= submit_tag "Remove selected", :class => 'btn btn-danger btn-sm add-selected-documents-btn' %>
         <% end %>
       </div>
     <% end %>
   <% end %>
   <tr>
-    <% if tab_state['search_results'] %>
+    <% if current_user.admin? || @anthology.user == current_user %>
       <th>Select</th>
     <% end %>
     <th>
@@ -50,7 +57,7 @@
   </tr>
   <% documents.each do |document| %>
     <tr>
-      <% if tab_state['search_results'] %>
+      <% if current_user.admin? || @anthology.user == current_user %>
         <td class="button-column">
           <%= check_box_tag 'document_ids[]', document.id, false, :class => 'document-checkbox' %>
         </td>
@@ -166,4 +173,18 @@
       $(function () {
         $('[data-toggle="tooltip"]').tooltip();
       });
+
+      const selectAll = () => {
+        const boxes = document.getElementsByClassName('document-checkbox')
+        for (let x = 0; x < boxes.length; x++) {
+          boxes[x].checked = true
+        }
+      }
+
+      const deselectAll = () => {
+        const boxes = document.getElementsByClassName('document-checkbox')
+        for (let x = 0; x < boxes.length; x++) {
+          boxes[x].checked = false
+        }
+      }
     </script>


### PR DESCRIPTION
# What this PR does

This PR adds batch removal capabilities to the "All" tab on the anthology document page. This required a bit of refactoring on the view to split each page into its own `form_tag`.

This PR also adds Select All and Deselect All buttons to make selecting documents easier. These buttons have a click listener that runs some very basic JS.

I think the features described in #417 and #418 are now fully implemented. Closes #417, #418, #420, and #421.

https://user-images.githubusercontent.com/64725469/177616155-b7338eed-d031-44cb-b259-fa02401d4f22.mov

# How to test

1. Visit an anthology page on the staging site.
2. Search for something that will bring up multiple pages of results (I used "dickens" in the Author field in the above video)
3. Go to any page other than 1
4. Select a few documents and click "Add selected"
5. You should be correctly redirected to the same page of results
6. Go to a different page and make sure "Select All" and "Deselect All" do what they claim to do
7. Click "Select All" and then "Add Selected" and make sure you're correctly redirected as in step 5
8. Click the "All" tab to see the documents in this anthology. Select some and click "Remove Selected", and they should be removed.