### PR TITLE
More informative CSV import error messages

### DIFF
--- a/app/assets/csv/example.csv
+++ b/app/assets/csv/example.csv
@@ -1,4 +1,4 @@
-email,firstname,Lastname
+email,firstname,lastname
 jane@janeausten.co.uk,Jane,Austen
 williamblake@covecollective.org,William,Blake
 ebronte@royalmail.co.uk,Emily,Brontë

--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -1,0 +1,3 @@
+module Exceptions
+  class CsvImportError < StandardError; end
+end


### PR DESCRIPTION
# What this PR does

This PR improves the error handling of the CSV invite system to nudge users in the right direction when something is incorrect. Specifically, it adds these two error messages:

![Screen Shot 2022-07-13 at 11 14 24 AM](https://user-images.githubusercontent.com/64725469/178769503-9a3953d5-7742-4c21-aa3b-027f80490222.png)

![Screen Shot 2022-07-13 at 11 14 34 AM](https://user-images.githubusercontent.com/64725469/178769517-df7cb654-891f-4909-8be9-f1de233a47d4.png)

# How to test

1. Go to https://staging.covecollective.org and open one of your anthologies.
2. Click the Users tab and the "Invite from CSV" button.
3. Upload something that's not a CSV file, e.g. an image or an Excel file.
4. You should receive the second error above.
5. Download this example CSV file: https://pastebin.com/raw/jnbJHFWb (notice it's intentionally missing the `lastname` field)
6. Try to upload it, and you should receive the first error above.
7. Download this correctly-formed CSV file: https://pastebin.com/raw/HwmKDeaD
8. Try to upload it.
9. You should get a success message, not an error.