### PR TITLE
Make text more specific on invitation page

### DIFF
--- a/app/views/users/invitations/edit.html.erb
+++ b/app/views/users/invitations/edit.html.erb
@@ -5,7 +5,7 @@
 
   <%= f.hidden_field :invitation_token %>
 
-  <h3>Please set up your account below:</h3>
+  <h3>You have been invited to a COVE Studio anthology. Log in to accept.</h3>
 
   <%= render :partial => "/devise/sessions/invite_sign_in", :locals => {:f => f, :resource => resource} %>
 <% end %>

--- a/config/locales/devise_invitable.en.yml
+++ b/config/locales/devise_invitable.en.yml
@@ -18,11 +18,11 @@ en:
     mailer:
       invitation_instructions:
         subject: "Invitation instructions"
-        hello: "Hello %{email}"
-        someone_invited_you: "Someone has invited you to %{url}, you can accept it through the link below."
+        hello: "Hello %{email},"
+        someone_invited_you: "Someone has invited you to a COVE Studio anthology at %{url}. You can accept the invitation through the link below."
         accept: "Accept invitation"
         accept_until: "This invitation will be due in %{due_date}."
-        ignore: "If you don't want to accept the invitation, please ignore this email.<br />\nYour account won't be created until you access the link above and set your password."
+        ignore: "If you don't want to accept the invitation, please ignore this email."
   time:
     formats:
       devise:


### PR DESCRIPTION
# What this PR does

This PR updates the text in the `devise-invitable` invitation view and in the invitation email to make it more clear that the user has been invited to an anthology.

It also removes the line about setting your password from the email, which was misleading as most tenants do not use password-based logins.

## View

![Screen Shot 2022-07-27 at 3 16 39 PM](https://user-images.githubusercontent.com/64725469/181354052-4c8c905b-4f37-4507-a1b6-d1e60a16e232.png)

## Email

![Screen Shot 2022-07-27 at 3 17 04 PM](https://user-images.githubusercontent.com/64725469/181354128-a47736fd-7928-4b05-bef6-6c5e88c61160.png)
