### PR TITLE
Update CSV import instructions to emphasize exact column names

### DIFF
--- a/app/views/anthologies/_users_tab.html.erb
+++ b/app/views/anthologies/_users_tab.html.erb
@@ -32,7 +32,7 @@
             <div class="csv-invite-how-to">
               <h5>How to use CSV imports:</h5>
               <p>Programs like Canvas and Blackboard usually offer the ability to export your list of students to a CSV file.</p>
-              <p>In order to set up student accounts with the proper attributes, COVE Studio needs the following columns: <em>email</em>, <em>firstname</em>, and <em>lastname</em>.</p>
+              <p>In order to set up student accounts with the proper attributes, COVE Studio needs the following columns: <em>email</em>, <em>firstname</em>, and <em>lastname</em>. Column headers must conform exactly to these titles (all lower case) so your column headings may need to be edited if your CSV file was downloaded.</p>
               <p>Use our <%= link_to("example file", asset_path("example.csv"), :target => "_new")%> as a guide.</p>
             </div>
             <%= form_tag({:action => :csv_import, :controller => :users}, :multipart => true) do %>


### PR DESCRIPTION
# What this PR does

This is a simple change to the instructions popup was suggested by the client to make it clearer to users that the CSV column names must be exact, i.e. all lower-case, etc. I simply copy/pasted the new sentence from Dino's email - it seems clear enough to me.

## Before

![Screen Shot 2022-07-28 at 4 19 12 PM](https://user-images.githubusercontent.com/64725469/181629798-40bd1943-78ed-406f-bd99-ad75195f2fa7.png)

## After

![Screen Shot 2022-07-28 at 4 13 35 PM](https://user-images.githubusercontent.com/64725469/181629660-b8574f2f-4a9e-466f-8e2d-690c57a98761.png)
