### PR TITLE
Improve invite logic for existing users

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -66,8 +66,10 @@ class UsersController < ApplicationController
           existing = User.find_by(email: user['email'])
           
           # Only reinvite existing users if they haven't accepted yet
-          unless existing && existing.invitation_accepted_at
-
+          # Also don't invite users who made accounts before invitations existed
+          if existing && (existing.invitation_accepted_at || existing.sign_in_count > 0)
+            invited_users.push(existing)
+          else
             new_user = User.invite!(
               email: user['email'],
               firstname: user['firstname'],


### PR DESCRIPTION
# What this PR does

This PR addresses an issue where existing users' logins would break if they were invited via the CSV import tool.

Previously, we checked for the `invitation_accepted_at` field when deciding whether to re-invite an existing user. But this field is `nil` for users who created their accounts before the invite system existed. To address this oversight, I've added another check for `sign_in_count > 0`, so someone who has successfully signed in before won't be re-invited.

# How to test

1. Tell me you're about to test this so I can turn on the COVE staging service worker.
2. Go to https://staging.covecollective.org/ and sign in with your main account.
3. Go to one of your anthologies with users in it.
4. Remove a user who has accepted their invitation.
5. Reinvite them with a CSV file.
6. They should a) be re-added to the anthology, b) with a green "Accepted" status, and c) **not receive** an invitation email.
7. Invite someone entirely new to the anthology with the CSV importer. Make sure to use an email address you can check (e.g. steve+7834879324@performant)
8. They should a) be added to the list, b) with an orange "Pending" status, and c) **recieve** an invitation email.