### PR TITLE
Add anthology to `rep_group_list` property for invited users

### DIFF
--- a/app/controllers/anthologies_controller.rb
+++ b/app/controllers/anthologies_controller.rb
@@ -1,4 +1,6 @@
 class AnthologiesController < ApplicationController
+  include ApplicationHelper
+
   before_filter :find_anthology, :only => [:show, :edit, :destroy]
   before_filter :authenticate_user!
 
@@ -149,9 +151,7 @@ class AnthologiesController < ApplicationController
       @searched_email = (params[:email] || [])
 
       if @anthology.present? && @user.present?
-        @anthology.users << @user
-        @user.rep_group_list.add(@anthology.slug)
-        @user.save
+        add_user_to_anthology(@user, @anthology)
         format.html {redirect_to anthology_path(@anthology, tab: "users", name: @searched_name, email: @searched_email), notice: "The user #{@user.email} was successfully added to this anthology"}
       else
         format.html { redirect_to anthologies_path(@anthology, tab: "users", name: @searched_name, email: @searched_email), error: "There was a problem adding the user to this anthology" }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,6 @@
 class UsersController < ApplicationController
+  include ApplicationHelper
+
   before_filter :authenticate_user!
 
   def show
@@ -88,18 +90,7 @@ class UsersController < ApplicationController
       if anthology_id.present?
         anthology = Anthology.find(anthology_id)
         for user in invited_users do
-          unless user.rep_group_list.include?(anthology.slug)
-            user.rep_group_list.add(anthology.slug)
-
-            # fix validation error by checking agreement box
-            user.agreement = true
-
-            user.save
-          end
-          unless anthology.users.include?(user)
-            anthology.users << user
-            anthology.save
-          end
+          add_user_to_anthology(user, anthology)
         end
       end
     rescue CSV::MalformedCSVError, ArgumentError, Exceptions::CsvImportError => e

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -88,7 +88,15 @@ class UsersController < ApplicationController
       if anthology_id.present?
         anthology = Anthology.find(anthology_id)
         for user in invited_users do
-          unless anthology.users.include? user
+          unless user.rep_group_list.include?(anthology.slug)
+            user.rep_group_list.add(anthology.slug)
+
+            # fix validation error by checking agreement box
+            user.agreement = true
+
+            user.save
+          end
+          unless anthology.users.include?(user)
             anthology.users << user
             anthology.save
           end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -58,4 +58,19 @@ module ApplicationHelper
     end
     false
   end
+
+  def add_user_to_anthology(user, anth)
+    unless user.rep_group_list.include?(anth.slug)
+      user.rep_group_list.add(anth.slug)
+
+      # fix validation error by checking agreement box
+      user.agreement = true
+
+      user.save
+    end
+    unless anth.users.include?(user)
+      anth.users << user
+      anth.save
+    end
+  end
 end


### PR DESCRIPTION
# What this PR does

This PR updates the CSV invite logic to append the anthology's slug to the users' `rep_group_list` tags, which matches the original `add_user` method.

In theory, this should fix the recently-reported bug in which students' annotations do not appear when the "All" settings are selected:

![Screen Shot 2022-08-30 at 11 03 48 AM](https://user-images.githubusercontent.com/64725469/187472237-55475304-f4a3-4ba2-be3b-858cfa437c3b.png)

However, I was unable to replicate the reported bug, so I cannot confirm whether this will fix the issue. Matching the invite method more closely to the `add_user` method should be a good idea anyway.