### PR TITLE
Fix broken folder creation in #436

### DIFF
--- a/app/controllers/anthologies_controller.rb
+++ b/app/controllers/anthologies_controller.rb
@@ -179,7 +179,7 @@ class AnthologiesController < ApplicationController
 
       if params[:commit] == 'Add to existing folder:'
         tag_name = params[:tag_name_dropdown]
-      elsif params[:commit] == 'Create and add:'
+      elsif params[:commit] == 'Create folder and add:'
         tag_name = params[:tag_name_new]
       end
 


### PR DESCRIPTION
# What this PR does

This PR fixes a bug in #436 that caused folder creation to fail.

It broke because I renamed the "Create folder and add" button without updating the controller logic to look for the new `:commit` field name. This one-line PR updates the name in the controller to match.