### PR TITLE
Enable folders feature for all users

### DIFF
--- a/app/views/anthologies/_searched_documents.erb
+++ b/app/views/anthologies/_searched_documents.erb
@@ -23,7 +23,7 @@
                 <span class='badge'><%= all_documents_count %></span> All
               <% end %>
             </li>
-            <% if @anthology.owned_tags.count > 0 || current_user.admin? %>
+            <% if @anthology.user == current_user || @anthology.owned_tags.count > 0 || current_user.admin? %>
               <li class="<%= tab_state['folders'] %>">
                 <%= link_to anthology_path( docs: 'folders', title: params[:title],author: params[:author], edition: params[:edition], id: anthology.friendly_id, tab: params[:tab] ), params do %>
                   <span class='badge'><%= @tag_count %></span> Folders


### PR DESCRIPTION
This PR updates the Folders feature to allow non-admin users to manage (i.e. create, add documents, remove documents) folders for anthologies that they own. 

**To Test:**
As a non-admin user, navigate to `/anthologies` and select an anthology owned by the user (or create one first if necessary). "Folders" tab should be visible (see screenshot below). Through the "Folders" tab, user should be able to create folders, add/remove documents to folders, and view contents of existing folders. "Folders" column should also appear on the "Documents" table if at least one folder exists (see screenshot below).

<img width="1160" alt="Screen Shot 2022-10-27 at 2 53 05 AM" src="https://user-images.githubusercontent.com/20568337/198226340-d5bbaaae-a2d5-42bc-a6ce-e54e46ec07f4.png">


<img width="1160" alt="Screen Shot 2022-10-27 at 2 53 54 AM" src="https://user-images.githubusercontent.com/20568337/198226348-c7910462-22af-4b09-bdc9-c56690995fcc.png">
