### PR TITLE
Set max height and overflow scrolling on folder grid

### DIFF
--- a/app/assets/stylesheets/anthologies.scss
+++ b/app/assets/stylesheets/anthologies.scss
@@ -93,8 +93,8 @@
   display: flex;
   gap: 10px;
   font-size: 1.5rem;
-  flex-wrap: wrap;
-  justify-content: center;
+  height: 170px;
+  overflow-x: scroll;
 }
 
 .anthology-folder-list-container a {
@@ -120,6 +120,8 @@
 .folder-document-count {
   font-size: 1.2rem;
   color: black;
+  line-height: 1;
+  text-align: center;
 }
 
 @media (max-width: 768px) {

--- a/app/assets/stylesheets/anthologies.scss
+++ b/app/assets/stylesheets/anthologies.scss
@@ -101,7 +101,7 @@
   display: flex;
   gap: 6px;
   align-items: center;
-  width: 200px;
+  min-width: 75px;
   flex-direction: column;
   line-height: 0.5rem;
 }


### PR DESCRIPTION
**What this PR does:**

- Sets fixed height and overflow scrolling on folder grid


**Steps to test:**

1. Navigate to an anthology that is owned by the current user (or any anthology if user is an admin)
2. Create 10 folders; folders should remain in one scrollable line (see "after" screenshots below) rather than expanding the parent container as a grid (see "before" screenshot below)

**Visual change(s):**

## Before
![Screen Shot 2022-11-06 at 12 07 21 AM](https://user-images.githubusercontent.com/20568337/200155939-ed33559e-05ba-4901-9ebb-ab640217c74c.png)


## After

![Screen Shot 2022-11-06 at 12 12 51 AM](https://user-images.githubusercontent.com/20568337/200155958-5fe1510c-b002-40e5-8e3c-587a8d384941.png)

## Layout with single folder
![Screen Shot 2022-11-06 at 12 24 10 AM](https://user-images.githubusercontent.com/20568337/200156008-7e95395e-9d02-4d2b-b447-0af27127a32c.png)
