### PR TITLE
Check for existing `@torontomu` address before changing

### DIFF
--- a/lib/tasks/ryerson_migration.rake
+++ b/lib/tasks/ryerson_migration.rake
@@ -3,8 +3,13 @@ task :ryerson_migration => :environment do
   tenant = Apartment::Tenant.switch('ryerson') do
     User.all.each do |u|
       if u.email.include? '@ryerson.ca'
-        u.email.sub! '@ryerson.ca' '@torontomu.ca'
-        u.save
+        # Make sure not to duplicate if the @torontumu account already exists
+        existing = User.find_by(email: u.email.sub '@ryerson.ca' '@torontomu.ca')
+
+        if !existing
+          u.email.sub! '@ryerson.ca' '@torontomu.ca'
+          u.save
+        end
       end
     end
   end


### PR DESCRIPTION
This PR updates the Ryerson migration rake task to prevent the possibility of creating accounts with duplicate email addresses.