### PR TITLE
Add `dry_run` arg to `ryerson_migration` rake task

### DIFF
--- a/lib/tasks/ryerson_migration.rake
+++ b/lib/tasks/ryerson_migration.rake
@@ -1,5 +1,11 @@
 desc 'Migrate the Ryerson tenant to Toronto MU'
-task :ryerson_migration => :environment do
+task :ryerson_migration, [:dry_run] => :environment do |t, args|
+  args.with_defaults(:dry_run => nil)
+
+  if args[:dry_run]
+    puts 'Running a dry run. No data will be written to the database.'
+  end
+
   tenant = Apartment::Tenant.switch('ryerson') do
     User.all.each do |u|
       if u.email.include? '@ryerson.ca'
@@ -8,8 +14,12 @@ task :ryerson_migration => :environment do
 
         if !existing
           u.email = u.email.sub('@ryerson.ca', '@torontomu.ca')
-          u.skip_reconfirmation!
-          u.save
+          if args[:dry_run]
+            puts u.inspect
+          else
+            u.skip_reconfirmation!
+            u.save
+          end
         end
       end
     end


### PR DESCRIPTION
This PR adds a new `dry_run` argument that will `puts` the new user objects to the console instead of saving them.

The arg needs to be called like this:
`bundle exec rake ryerson_migration[dry_run]`

You have to use Bash, rather than `zsh`, because `zsh` can't handle brackets.

I have no idea why CLI arguments in Rake tasks are so annoying.

In addition, I've tested the script locally with production data and confirmed that it works correctly.