### PR TITLE
Fix typo in document import task

### DIFF
--- a/lib/tasks/copy_vetted_documents.rake
+++ b/lib/tasks/copy_vetted_documents.rake
@@ -31,7 +31,7 @@ task :copy_vetted_documents, [:source_tenant, :destination_tenant, :user_email, 
   end
 
   # switch back to starting tenant
-  Apartment::tenant.switch!(starting_tenant)
+  Apartment::Tenant.switch!(starting_tenant)
 
   log_action(log_string, "Done at #{Time.now.strftime("%I:%M:%S")}")
 


### PR DESCRIPTION
This PR fixes a typo where `Apartment::tenant` should have been `Apartment::Tenant`, which caused a crash in the document import script.