### PR TITLE
Add minimal docs about tmu mongo migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,10 @@ Especially note the `wantsAssertionsSigned="false"`. Turning off encrypted asser
 1. If a domain does not have a matching Tenant, the default "public" tenant will be used.
 2. Admin users are shared across all tenants, and therefore shouldn't be created and granted to single-tenant users
 
+## Tenant Name Changes
+
+For future reference, the Mongo query for updating annotations when a tenant changes their name/email is available at `doc/torontomu_annotations_mongo_query`.
+
 ## User Support and Developer forum
 http://support.annotationstudio.org
 

--- a/doc/torontomu_annotations_mongo_query.md
+++ b/doc/torontomu_annotations_mongo_query.md
@@ -1,0 +1,101 @@
+### Update user emails
+
+```
+db.annotations.updateMany({
+  user: {
+    $regex: /@ryerson.ca/
+  },
+  uri: {
+    $regex: /ryerson.covecollective.org|torontomu.covecollective.org/
+  }
+},
+[
+  {
+    "$set": {
+      "user": {
+        "$replaceAll": {
+          "input": "$user",
+          "find": "ryerson.ca",
+          "replacement": "torontomu.ca"
+        }
+      },
+      "permissions.admin": {
+        $map: {
+          input: "$permissions.admin",
+          as: "item",
+          in: {
+            $replaceOne: {
+              input: "$$item",
+              find: "@ryerson.ca",
+              replacement: "@torontomu.ca"
+            }
+          }
+        }
+      },
+      "permissions.delete": {
+        $map: {
+          input: "$permissions.delete",
+          as: "item",
+          in: {
+            $replaceOne: {
+              input: "$$item",
+              find: "@ryerson.ca",
+              replacement: "@torontomu.ca"
+            }
+          }
+        }
+      },
+      "permissions.read": {
+        $map: {
+          input: "$permissions.read",
+          as: "item",
+          in: {
+            $replaceOne: {
+              input: "$$item",
+              find: "@ryerson.ca",
+              replacement: "@torontomu.ca"
+            }
+          }
+        }
+      },
+      "permissions.update": {
+        $map: {
+          input: "$permissions.update",
+          as: "item",
+          in: {
+            $replaceOne: {
+              input: "$$item",
+              find: "@ryerson.ca",
+              replacement: "@torontomu.ca"
+            }
+          }
+        }
+      },
+    }
+  }
+])
+```
+
+### Update annotation URIs
+
+```
+db.annotations.updateMany({
+  "uri": {
+    $regex: /ryerson.covecollective.org/
+  }
+},
+[
+  {
+    "$set": {
+      "uri": {
+        "$replaceAll": {
+          "input": "$uri",
+          "find": "ryerson.covecollective.org",
+          "replacement": "torontomu.covecollective.org"
+        }
+      },
+      
+    }
+  }
+])
+```


### PR DESCRIPTION
This PR adds a Markdown file to the `docs` folder that contains the Mongo queries we used in the TMU name migration, along with a note in the README referring readers to it.