### PR TITLE
Update metadata ID for UMich

### DIFF
--- a/app/views/saml/umich_metadata.xml
+++ b/app/views/saml/umich_metadata.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" entityID="https://umich.covecollective.org/sp/metadata" ID="COVE Studio Staging">
+<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" entityID="https://umich.covecollective.org/sp/metadata" ID="cove-studio">
   <SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
     <KeyDescriptor use="signing">
       <ds:KeyInfo>

--- a/app/views/saml/umich_staging_metadata.xml
+++ b/app/views/saml/umich_staging_metadata.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" entityID="https://umich-staging.covecollective.org/sp/metadata" ID="COVE Studio Staging">
+<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" entityID="https://umich-staging.covecollective.org/sp/metadata" ID="cove-studio-staging">
   <SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
     <KeyDescriptor use="signing">
       <ds:KeyInfo>


### PR DESCRIPTION
This PR changes the `ID` field to one that passes the validator at https://www.samltool.com/validate_xml.php

Technically "COVE Studio" is not a valid ID - I assume previous tenants worked around the issue. We should start using `cove-studio` and `cove-studio-staging` for future metadata files.