### PR TITLE
Use alternative method for counting documents in folders

### DIFF
--- a/app/helpers/anthologies_helper.rb
+++ b/app/helpers/anthologies_helper.rb
@@ -9,7 +9,7 @@ module AnthologiesHelper
       taggable_type: 'Document',
       tagger_type: 'Anthology',
       context: 'rep_folder'
-    ).joins(:tag).select('taggings.*, tags.name')
+    ).joins(:tag).select('tags.name')
 
     folders = []
 

--- a/app/helpers/anthologies_helper.rb
+++ b/app/helpers/anthologies_helper.rb
@@ -1,2 +1,26 @@
 module AnthologiesHelper
+  def get_folders(anthology)
+    tags = ActsAsTaggableOn::Tagging.where(
+      tagger_id: anthology.id,
+      taggable_type: 'Document',
+      tagger_type: 'Anthology',
+      context: 'rep_folder'
+    ).joins(:tag).select('taggings.*, tags.*')
+
+    folders = []
+
+    tags.each do |t|
+      existing = folders.find { |f| f[:name] == t.name }
+      if existing
+        existing[:count] += 1
+      else
+        folders.push({
+          name: t.name,
+          count: 1
+        })
+      end
+    end
+
+    folders
+  end
 end

--- a/app/helpers/anthologies_helper.rb
+++ b/app/helpers/anthologies_helper.rb
@@ -1,11 +1,15 @@
 module AnthologiesHelper
+
+  # Generate a list that contains the name
+  # of each folder in the given anthology  
+  # and the number of documents within it.
   def get_folders(anthology)
     tags = ActsAsTaggableOn::Tagging.where(
       tagger_id: anthology.id,
       taggable_type: 'Document',
       tagger_type: 'Anthology',
       context: 'rep_folder'
-    ).joins(:tag).select('taggings.*, tags.*')
+    ).joins(:tag).select('taggings.*, tags.name')
 
     folders = []
 

--- a/app/views/anthologies/_folder_list.html.erb
+++ b/app/views/anthologies/_folder_list.html.erb
@@ -3,7 +3,7 @@
     <%= link_to anthology_path(anthology: @anthology.id, folder: tag.name, docs: 'folders'), :class => "#{'selected-folder-link' if params[:folder] == tag.name}" do %>
       <%= image_tag('folder-fill.svg') %>
       <p><%= tag.name %></p>
-      <p class='folder-document-count'><%= tag.taggings_count %> document<%= 's' if tag.taggings_count != 1 %></p>
+      <p class='folder-document-count'><%= @anthology.documents.tagged_with(tag.name).count  %> document<%= 's' if tag.taggings_count != 1 %></p>
     <% end %>
   <% end %>
 </div>

--- a/app/views/anthologies/_folder_list.html.erb
+++ b/app/views/anthologies/_folder_list.html.erb
@@ -1,9 +1,9 @@
 <div class="anthology-folder-list-container">
-  <% @anthology.owned_tags.sort { |a, b| a.name <=> b.name }.each do |tag| %>
-    <%= link_to anthology_path(anthology: @anthology.id, folder: tag.name, docs: 'folders'), :class => "#{'selected-folder-link' if params[:folder] == tag.name}" do %>
+  <% get_folders(@anthology).sort { |a, b| a[:name] <=> b[:name] }.each do |folder| %>
+    <%= link_to anthology_path(anthology: @anthology.id, folder: folder[:name], docs: 'folders'), :class => "#{'selected-folder-link' if params[:folder] == folder[:name]}" do %>
       <%= image_tag('folder-fill.svg') %>
-      <p><%= tag.name %></p>
-      <p class='folder-document-count'><%= @anthology.documents.tagged_with(tag.name).count  %> document<%= 's' if tag.taggings_count != 1 %></p>
+      <p><%= folder[:name] %></p>
+      <p class='folder-document-count'><%= folder[:count]  %> document<%= 's' if folder[:count] != 1 %></p>
     <% end %>
   <% end %>
 </div>


### PR DESCRIPTION
# Summary

As per #466, this PR updates the way the number of tags is calculated to be correct.

Instead of `tag.taggings_count`, which was incorrectly scoped, the folder list now uses a helper method that does the same thing, but correctly this time.

Closes #466 

## Testing

Working with two different anthologies on staging:

1. Create a folder with the same name in both anthologies.
2. Add documents to the folder in both anthologies.
3. The number of documents listed below the folder icon should be the number you've added to the folder *in this anthology*, rather than the combined total for both.
4. Play around with the folder feature a bit more to make sure the number listed always matches the number of documents that appear when you click the folder.
5. The page that lists the folders shouldn't take too long to load.