### PR TITLE
Switch to Postmark for email delivery

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,6 +61,8 @@ gem 'will_paginate-bootstrap'
 
 gem 'exception_notification'
 
+gem 'postmark-rails'
+
 gem "melcatalog", :path => "vendor"
 gem "rest-client"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -470,6 +470,11 @@ GEM
       html_writer (~> 0.2.0)
       pdf-reader (~> 1.1.0)
     pg (1.4.6)
+    postmark (1.24.0)
+      json
+    postmark-rails (0.22.1)
+      actionmailer (>= 3.0.0)
+      postmark (>= 1.21.3, < 2.0)
     public_suffix (4.0.7)
     puma (6.1.1)
       nio4r (~> 2.0)
@@ -638,6 +643,7 @@ DEPENDENCIES
   pdf-reader
   pdf-reader-html
   pg (~> 1.1)
+  postmark-rails
   puma
   rabl
   rails (~> 6.1, >= 6.1.7.3)

--- a/app.json
+++ b/app.json
@@ -165,17 +165,10 @@
     "SECRET_KEY_BASE": {
       "required": true
     },
-    "SENDGRID_PASSWORD": {
-      "required": true
-    },
-    "SENDGRID_USERNAME": {
-      "required": true
-    },
     "UNICORN_BACKLOG": "16"
   },
   "addons": [
-    "heroku-postgresql:hobby-dev",
-    "sendgrid:starter"
+    "heroku-postgresql:hobby-dev"
   ],
   "formation": {
     "worker": {

--- a/config/application.sample.yml
+++ b/config/application.sample.yml
@@ -34,8 +34,6 @@ development:
     AWS_SECRET_ACCESS_KEY:                 "xxxxxx"
     EMAIL_DOMAIN:                          "staging-annotationstudio.herokuapp.com"
     S3_BUCKET_NAME:                        "annotationstudio-public"
-    SENDGRID_PASSWORD:                     "xxxx"
-    SENDGRID_USERNAME:                     "xxxx"
 
 production:
     DEFAULT_NEW_USER_GROUP: public
@@ -73,5 +71,3 @@ production:
     AWS_SECRET_ACCESS_KEY:                 "xxxxxx"
     EMAIL_DOMAIN:                          "staging-annotationstudio.herokuapp.com"
     S3_BUCKET_NAME:                        "annotationstudio-public"
-    SENDGRID_PASSWORD:                     "xxxx"
-    SENDGRID_USERNAME:                     "xxxx"

--- a/config/database.yml
+++ b/config/database.yml
@@ -5,6 +5,7 @@ development: &default
   host: localhost
   pool: 5
   timeout: 5000
+  gssencmode: disable
 
 test:
   <<: *default

--- a/config/database.yml
+++ b/config/database.yml
@@ -5,7 +5,9 @@ development: &default
   host: localhost
   pool: 5
   timeout: 5000
-  gssencmode: disable
+  # If you have issues running the datbase
+  # locally, try uncommenting the line below.
+  # gssencmode: disable
 
 test:
   <<: *default

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -45,19 +45,14 @@ Rails.application.configure do
   # number of complex assets.
   config.assets.debug = true
 
+  config.action_mailer.delivery_method = :postmark
+  config.action_mailer.postmark_settings = { :api_token => ENV['POSTMARK_TOKEN'] }
+
+  config.action_mailer.raise_delivery_errors = true
   config.action_mailer.default_url_options = { :host => 'localhost:3000' }
   config.action_mailer.perform_deliveries = true
-  config.action_mailer.delivery_method = :smtp
+  # config.action_mailer.delivery_method = :smtp
   config.action_mailer.default :charset => "utf-8"  
-  config.action_mailer.smtp_settings =  {
-    :address  => "smtp.postmarkapp.com",
-    :domain  => "covecollective.org",
-    :port  => 587,
-    :user_name  => ENV['POSTMARK_TOKEN'],
-    :password  => ENV['POSTMARK_TOKEN'],
-    :authentication  => :plain,
-    :enable_starttls_auto => true
-  }
 
   # Adds additional error checking when serving assets at runtime.
   # Checks for improperly declared sprockets dependencies.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -51,7 +51,6 @@ Rails.application.configure do
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.default_url_options = { :host => 'localhost:3000' }
   config.action_mailer.perform_deliveries = true
-  # config.action_mailer.delivery_method = :smtp
   config.action_mailer.default :charset => "utf-8"  
 
   # Adds additional error checking when serving assets at runtime.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -70,18 +70,10 @@ Rails.application.configure do
   config.active_support.deprecation = :notify
 
   config.action_mailer.default_url_options = { :host => ENV['EMAIL_DOMAIN'] }
+  config.action_mailer.postmark_settings = { :api_token => ENV['POSTMARK_TOKEN'] }
   config.action_mailer.perform_deliveries = true
-  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.delivery_method = :postmark
   config.action_mailer.default :charset => "utf-8"
-  config.action_mailer.smtp_settings = {
-    :address        => "smtp.sendgrid.net",
-    :port           => "587",
-    :authentication => :plain,
-    :user_name      => ENV['SENDGRID_USERNAME'],
-    :password       => ENV['SENDGRID_PASSWORD'],
-    :domain         => ENV['SENDGRID_DOMAIN'],
-    :enable_starttls_auto => false
-  }
 
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -69,6 +69,7 @@ Rails.application.configure do
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify
 
+  config.action_mailer.raise_delivery_errors = true
   config.action_mailer.default_url_options = { :host => ENV['EMAIL_DOMAIN'] }
   config.action_mailer.postmark_settings = { :api_token => ENV['POSTMARK_TOKEN'] }
   config.action_mailer.perform_deliveries = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -60,7 +60,7 @@ Rails.application.configure do
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.raise_delivery_errors = false
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -60,7 +60,7 @@ Rails.application.configure do
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
@@ -69,7 +69,6 @@ Rails.application.configure do
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify
 
-  config.action_mailer.raise_delivery_errors = true
   config.action_mailer.default_url_options = { :host => ENV['EMAIL_DOMAIN'] }
   config.action_mailer.postmark_settings = { :api_token => ENV['POSTMARK_TOKEN'] }
   config.action_mailer.perform_deliveries = true

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -44,6 +44,7 @@ AnnotationStudio::Application.configure do
   # Print deprecation notices to the stderr
   config.active_support.deprecation = :stderr
 
+  config.action_mailer.raise_delivery_errors = true
   config.action_mailer.default_url_options = { :host => ENV['EMAIL_DOMAIN'] }
   config.action_mailer.postmark_settings = { :api_token => ENV['POSTMARK_TOKEN'] }
   config.action_mailer.perform_deliveries = true

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -45,15 +45,8 @@ AnnotationStudio::Application.configure do
   config.active_support.deprecation = :stderr
 
   config.action_mailer.default_url_options = { :host => ENV['EMAIL_DOMAIN'] }
+  config.action_mailer.postmark_settings = { :api_token => ENV['POSTMARK_TOKEN'] }
   config.action_mailer.perform_deliveries = true
-  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.delivery_method = :postmark
   config.action_mailer.default :charset => "utf-8"
-  config.action_mailer.smtp_settings = {
-    :address        => "smtp.sendgrid.net",
-    :port           => "587",
-    :authentication => :plain,
-    :user_name      => ENV['SENDGRID_USERNAME'],
-    :password       => ENV['SENDGRID_PASSWORD'],
-    :domain         => ENV['SENDGRID_DOMAIN']
-  }
 end

--- a/config/initializers/mail.rb
+++ b/config/initializers/mail.rb
@@ -1,11 +1,3 @@
 if ['production', 'staging', 'public'].include?(Rails.env)
-  ActionMailer::Base.smtp_settings = {
-   :address        => 'smtp.sendgrid.net',
-   :port           => '587',
-   :authentication => :plain,
-   :user_name      => ENV['SENDGRID_USERNAME'],
-   :password       => ENV['SENDGRID_PASSWORD'],
-   :domain         => 'heroku.com'
-  }
-  ActionMailer::Base.delivery_method = :smtp
+  ActionMailer::Base.delivery_method = :postmark
 end


### PR DESCRIPTION
# Summary

- switches from using Sendgrid via SMTP to Postmark via the official `postmark-rails` gem, which uses the Postmark API

Using the Postmark API rather than SMTP will provide more clarity if/when email delivery issues occur in the future.

Closes #462 

# To do

We still need to add covecollective.org as an authorized sender on Postmark.

# Testing

1. Go to the staging site (let me know first so I can deploy this branch to staging)
2. Invite some users to an anthology with email addresses that link to your Performant email using the `+` trick
3. The invitation emails should arrive in your inbox