### PR TITLE
add `config.hosts.clear` to development.rb file

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -62,4 +62,5 @@ Rails.application.configure do
   # config.action_view.raise_on_missing_translations = true
 
   config.log_level = :debug
+  config.hosts.clear
 end


### PR DESCRIPTION
This change seems to be necessary as of the latest Rails version to avoid SSL errors when working locally.